### PR TITLE
2019-12-30最新版yang文件

### DIFF
--- a/CMCC-SPTN-SBI-Yang-20190723/of-config-1.2-sptn-alarm.yang
+++ b/CMCC-SPTN-SBI-Yang-20190723/of-config-1.2-sptn-alarm.yang
@@ -1,0 +1,173 @@
+module of-config-1.2-sptn-alarm {
+ namespace 'http://chinamobile.com.cn/sdn/sptn/sbi/schema/alm' ;
+
+ prefix sptn-alm ;
+
+ import of-config-1.2 { prefix of-config; }
+ import ietf-yang-types { prefix yang-types; }
+ import of-config-1.2-sptn-oam { prefix sptn-oam; }
+
+ organization "SPTN Working Group";
+ contact "SPTN OpenFlow Extensions";
+
+ description
+ "This version of this YANG Module is made in 2018-05-09. modify alarm-shield into alarm-mask on the version of 2018-05-02.";
+
+ revision 2018-05-09 {
+  description
+  "This version of this YANG Module is made in 2016/03/29.";
+}
+
+
+typedef severity-classification {
+  type enumeration {
+    enum critical {
+      value 1 ;
+      description "severity-classification critical";
+    }
+    enum major {
+      value 2 ;
+      description "severity-classification major";
+    }
+    enum minor {
+      value 3 ;
+      description "severity-classification minor";
+    }
+    enum warning {
+      value 4 ;
+      description "severity-classification warning";
+    }
+  }
+  description "severity classification";
+} 
+typedef alarm-status {
+  type enumeration {
+    enum occurred {
+      value 1 ;
+      description "alarm occurred";
+    }
+    enum cleared {
+      value 2 ;
+      description "alarm cleared";
+    }
+  }
+  description "alarm status";
+}
+
+grouping alarm-report {
+  description "Common elements for alarm lists";
+
+  uses "of-config:OFResourceType" {
+   description "Resource-id of the resource raising the alarm - port, MEG, etc." ;
+ }      
+
+ list almCodelist {
+  key "almcode";
+  leaf SequenceNo {
+    type uint32 {
+      range "1..4294967295";
+    }
+  }
+  leaf almcode {
+    type uint32 ;
+    description "alarm code" ;
+  }
+  leaf severity {
+    type severity-classification ;
+    description "severity classification" ;
+  }
+  leaf timestamp {
+    type "yang-types:timestamp";
+    description "the timestamp is the number of seconds since 2000/01/01 00:00:00" ;
+  }
+  leaf alarm-status {
+    type alarm-status ;
+    description "alarm status" ;
+  }
+  leaf description {
+    type string {
+      length "1..255" ;
+    }
+    description "the alarm description" ;
+  }
+}
+}
+
+
+notification current-alarm-report {
+
+  list alarmReportlist {
+    key "OFLogicalSwitchId resource-id";
+    leaf OFLogicalSwitchId {
+      type "of-config:OFConfigId" ;
+    }
+    uses alarm-report ;
+  }
+  }  // notification
+
+  notification protection-status-report {
+
+    leaf SequenceNo {
+      type uint32 {
+        range "1..4294967295";
+      }
+    }
+
+    uses "of-config:OFResourceType" {
+     description "Resource-id of the protection group." ;
+   }      
+
+   leaf OFLogicalSwitchId {
+    type "of-config:OFConfigId" ;
+  }
+
+  uses "sptn-oam:protection-status" ;
+
+  leaf lastWatchportOfSwitcher {
+    type uint32 ;
+  }
+
+  leaf currentWatchportOfSwitcher {
+    type uint32 ;
+  }
+
+  }  // notification
+
+  grouping current-alarm-group {
+    container current-alarm {
+      description "Current alarms for this logical switch";
+      config false;
+      list alarmlist {
+        key "resource-id";
+        uses alarm-report;
+      }
+    } // container
+
+    container alarm-management {
+      description
+        "alarm management functions.";
+
+      list alarmConfiglist {
+        description
+        "Alarm mask configuration by alarm type.";
+        key "almcode";
+        leaf almcode {
+            type uint32 ;
+              description "alarm code";
+            }
+
+        leaf alarm-mask {
+            type boolean;
+            default "false";
+        }
+      }
+    }
+  }
+
+  augment "/of-config:capable-switch/of-config:logical-switches/of-config:switch" {
+      uses current-alarm-group;
+    
+
+  } // augment
+
+} // module

--- a/CMCC-SPTN-SBI-Yang-20190723/of-config-1.2-sptn-clock.yang
+++ b/CMCC-SPTN-SBI-Yang-20190723/of-config-1.2-sptn-clock.yang
@@ -251,7 +251,8 @@ module of-config-1.2-sptn-clock {
       }
       leaf-list system-clock-source-priority-list {
         type string;
-      
+             ordered-by user;
+   
         description
           "The list of port priority.";
       }

--- a/CMCC-SPTN-SBI-Yang-20190723/of-config-1.2-sptn-device.yang
+++ b/CMCC-SPTN-SBI-Yang-20190723/of-config-1.2-sptn-device.yang
@@ -1,0 +1,987 @@
+module of-config-1.2-sptn-device {
+  namespace 'http://chinamobile.com.cn/sdn/sptn/sbi/schema/device' ;
+  prefix "sptn-device";
+
+  import of-config-1.2 { prefix of-config; }
+  import ietf-yang-types { prefix yang; }
+  import ietf-inet-types { prefix inet; }
+
+  organization "SPTN Working Group";
+  contact "SPTN OpenFlow Extensions";
+  description "SPTN Device Yang Module";
+
+  revision "2018-05-09" {
+    description "initial";
+    reference "sptn openflow extensions draft";
+  }
+
+  typedef connector-type {
+        type enumeration {
+            enum "SC" {
+                value 1;
+            }
+            enum "LC" {
+                value 2;
+            }
+       }
+    }
+    typedef fiber-type {
+        type enumeration {
+            enum "single" {
+                value 1;
+            }
+            enum "double" {
+                value 2;
+            }
+       }
+    }
+
+    typedef sfp-present-type {
+        type enumeration {
+            enum "present" {
+                value 1;
+            }
+            enum "notPresent" {
+                value 2;
+            }
+            enum "notSupport" {
+                value 3;
+            }
+       }
+    }
+    typedef opt-module-type {
+        type enumeration {
+            enum "SFP" {
+                value 1;
+            }
+            enum "SFF" {
+                value 2;
+            }
+            enum "XFF" {
+                value 3;
+            }
+            enum "SFP PLUS" {
+                value 4;
+            }
+            enum "XFP" {
+                value 5;
+            }
+            enum "XFP-E" {
+                value 6;
+            }
+            enum "GBIC" {
+                value 7;
+            }
+            enum "XPak" {
+                value 8;
+            }
+            enum "X2" {
+                value 9;
+            }
+            enum "DWDM-SFP" {
+                value 10;
+            }
+            enum "QSFP" {
+                value 11;
+            }
+            enum "300 pin XBI" {
+                value 12;
+            }
+            enum "Unknown" {
+                value 13;
+            }
+       }
+    }
+
+    typedef opt-media-type {
+        type enumeration {
+            enum "singleMode" {
+                value 1;
+            }
+            enum "multiMode" {
+                value 2;
+            }
+       }
+    }
+    typedef opt-laser-status-type {
+        type enumeration {
+            enum "shutdown" {
+                value 1;
+            }
+            enum "open" {
+                value 2;
+            }
+       }
+    }
+
+    typedef opt-ddm-support-type {
+        type enumeration {
+            enum "support" {
+                value 1;
+            }
+            enum "notSupport" {
+                value 2;
+            }
+       }
+    }
+
+    typedef opt-wave-length-type {
+        type enumeration {
+            enum "wavelength_1310nm" {
+                value 1;
+            }
+            enum "wavelength_1550nm" {
+                value 2;
+            }
+            enum "wavelength_850nm" {
+                value 3;
+            }
+            enum "wavelength_1490nm" {
+                value 4;
+            }
+            enum "wavelength_1530nm" {
+                value 5;
+            }
+            enum "wavelength_1610nm" {
+                value 6;
+            }
+            enum "wavelength_unknown" {
+                value 7;
+            }			
+        }
+    }
+
+    typedef port-type {
+        type enumeration {
+            enum "optical" {
+                value 1;
+            }
+            enum "electrical" {
+                value 2;
+            }
+       }
+    }
+
+    typedef node-type {
+        type enumeration {
+            enum "CPE" {
+                value 1;
+            }
+            enum "HUB" {
+                value 2;
+            }
+            enum "Unknown" {
+                value 3;
+            }
+       }
+    }
+
+    typedef admin-status-type {
+        type enumeration {
+          enum "up" {
+              value 1;
+          }
+          enum "down" {
+              value 2;
+          }
+       }
+    }
+
+    typedef oper-status-type {
+        type enumeration {
+          enum "null" {
+              value 1;
+          }
+          enum "initing" {
+              value 2;
+          }
+          enum "upgrating" {
+              value 3;
+          }
+          enum "running" {
+              value 4;
+          }
+          enum "exception" {
+              value 5;
+          }
+       }
+    }
+
+    typedef master-mode-type {
+        type enumeration {
+          enum "master" {
+              value 1;
+          }
+          enum "slave" {
+              value 2;
+          }
+          enum "none" {
+              value 3;
+          }
+       }
+    }
+
+    typedef dev-oper-status-type {
+        type enumeration {
+            enum "up" {
+                value 1;
+            }
+            enum "down" {
+                value 2;
+            }
+       }
+    }
+
+    typedef reset-comoman-type {
+        type enumeration {
+            enum "none" {
+                value 1;
+            }
+            enum "reset" {
+                value 2;
+            }
+       }
+    }
+
+    typedef save-command-type {
+        type enumeration {
+            enum "none" {
+                value 1;
+            }
+            enum "save" {
+                value 2;
+            }
+       }
+    }
+
+    typedef alarm-inverse-mode-type {
+      type enumeration {
+        enum "un-inverse" {
+            value 0;
+            description "Disable alarm-inverse function.you can't enable port alram-inverse ";
+        }
+        enum "automatic" {
+            value 1;
+            description "In automaic mode,you can enable/disable port alram-inverse.
+                  If port isn't used,don't report alarm.when port is used,report alarm normally.";
+        }
+        enum "manual" {
+            value 2;
+            description "In manual mode,you can enable/disable port alram-inverse.
+            Report the inverse alarm status of port.";
+        }
+    }
+} 
+
+
+  grouping manage-vlan-group {
+    container manage-vlan {
+      description
+      "the normal vlan in which packets forward based on L2 mac learning. This 
+      vlan is automaticly created by the switch when powered up. In this
+      vlan, the ip address and default route are configued so that the 
+      switch can connect to the controller, and other deives can use the 
+      vlan as a path to link to controller.";
+
+      leaf vid {
+        type uint32 {
+          range "1..4094";
+        }
+        description
+        "The vid of the vlan, It is predefined by China mobile.";
+      }
+
+      leaf-list port {
+        type leafref {
+          path "/of-config:capable-switch/of-config:resources/of-config:port/of-config:resource-id";
+        }
+        description
+        "A resource identifier of a port of the OpenFlow Capable
+        Switch that the OpenFlow Logical Switch has exclusive access to.
+
+        Elements in this list MUST be unique. This means each
+        port element can only be referenced once.";
+      }
+
+      leaf manage-ip-address {
+        type inet:ip-address;
+        description
+        "Local ip address for the switch. this ip normally got through dhcp server,
+        but the controller can modify it, too.";
+      }
+
+      leaf manage-ip-mask {
+        type uint8 {
+          range "0..32";
+        }
+        description
+        "Ip address mask.";
+      }
+
+      leaf default-route {
+        type inet:ip-address;
+        description
+        "Default route of the switch. this ip normally got through dhcp server,
+        but the controller can modify it, too.";
+      }
+    }
+  }
+
+  grouping OFCardType {
+        leaf slot-num {
+          type uint16;
+          config false;
+          description
+            "The number of the slot.";
+        }
+        leaf card-name {
+          type string;
+          config false;
+          description
+            "The name of the card.";
+        }
+        leaf card-desc {
+          type string;
+          description
+            "The description of the card.";
+        }
+        leaf manufacture-info {
+          type string;
+          config false;
+          description
+            "The manufacture information, for example,the factory information.";
+        }
+        leaf serial-num {
+          type string;
+          config false;
+          description
+              "The vendor-specific serial number string for the
+              card.  The preferred value is the serial number
+              string actually printed on the card itself (if
+              present).";
+        }
+        leaf card-temperature {
+          type string;
+          config false;
+          description
+            "The temperature of the card.";
+        }
+        leaf cpu-utilization {
+          type uint16;
+          config false;
+          description
+            "The cpu utilization of card.The unit is %.";
+        }
+        leaf memory-utilization {
+          type uint16;
+          config false;
+          description
+              "The memory utilization of card.The unit is %.";
+        }
+        leaf cpu-utilization-high-thr {
+          type uint16{
+          range "60..100";
+        }
+         default 80;
+          description
+            "The cpu utilization high alarm threshold of card.The unit is %.";
+        }
+        leaf memory-utilization-high-thr {
+          type uint16{
+            range "60..100";
+          } 
+          default 80;
+          description
+              "The memory utilization high alarm threshold of card.The unit is %.";
+        }   
+        leaf card-temperature-high-thr{
+          type int16{
+            range "-10..60";
+          }
+          default 50;
+          description
+            "The temperature high alarm threshold of the card.The unit is degree Celsius";
+        }
+        leaf card-temperature-low-thr{
+          type int16{
+            range "-10..60";
+          }
+          default 0;
+          description
+            "The temperature high alarm threshold of the card.The unit is degree Celsius";
+        }             
+        leaf oper-status {
+          type oper-status-type;
+          config false;
+          description
+            "The working status of card.";
+        }
+        leaf master-mode {
+          type master-mode-type;
+          config false;
+          description
+              "The master mode, master or slave for main control  or E1 board.";
+        }
+        leaf software-version {
+          type string;
+          config false;
+          description
+              "The vendor-specific software revision string for the
+              card.";
+        }
+        leaf hardware-version {
+          type string ;
+          config false;
+          description
+            "The vendor-specific hardware revision string for the
+              card.  The preferred value is the hardware revision
+              identifier actually printed on the card itself (if
+              present).";
+        }
+        leaf firmware-version {
+          type string;
+          config false;
+          description
+            "The vendor-specific firmware revision string for the
+              card.";
+        }
+        leaf boot-version {
+          type string;
+          config false;
+          description           
+	   "The vendor-specific boot revision string for the card.";
+        }
+        leaf-list port {
+            type leafref {
+                path "/of-config:capable-switch/of-config:resources/of-config:port/of-config:resource-id";
+            }
+            description
+            "Reference to port resources in the Capable Switch.
+            This element associates ports with card.";
+        }
+        uses OFAlarmMaskType;
+    }
+
+    grouping OFSysTimeType {
+        leaf sys-time {
+            type yang:date-and-time;        
+            description
+                "The time of system.The controller can set the system time 
+                 same to the server time.";
+        }
+    }
+
+    grouping OFDevResetType {
+        leaf reset-command {
+            type reset-comoman-type;
+            description
+                "The command of reset the device.";
+        }
+    }
+
+    grouping OFDevSaveType {
+        leaf save-command {
+            type save-command-type;
+            description
+                "The command of reset the device.";
+        }
+    }
+
+
+    grouping OFNodeType {
+        leaf type {
+            type node-type;
+            
+            description
+                "The device type,HUB or CPE (if known) or unknown.";
+        }
+        leaf name {
+            type string {
+                length "1..32";
+            }
+            config false;
+            description
+                "The device name of the vendor specific.";
+        }
+        leaf description {
+            type string;
+            description
+                "A textual description of device.";
+        }
+        leaf vendor {
+            type string;
+            config false;
+            description
+                "The name of the vendor.";
+        }
+        leaf firmware-rev {
+            type string;
+            config false;
+            description
+                "The vendor-specific firmware revision string for the
+              device.";
+        }
+
+        leaf software-rev {
+            type string;
+            config false;
+            description
+                "The vendor-specific software revision string for the
+              device.";
+        }
+        leaf hardware-rev {
+            type string;
+            config false;
+            description
+                "The vendor-specific hardware revision string for the
+              device.  The preferred value is the hardware revision
+              identifier actually printed on the device itself (if
+              present)";
+        }
+        leaf boot-version {
+            type string;
+            config false;
+            description
+                "The boot version.";
+        }
+        leaf oper-status {
+            type dev-oper-status-type;
+            config false; 
+            description
+                "The working status of the device,up or down.";
+        }
+        leaf mac-addr {
+            type yang:mac-address;
+            config false;
+            description
+                "The Mac-address of the device.";
+        }
+        leaf run-time {
+            type uint32;
+            config false;
+            description
+                "The running time of device since power on. Device update this run-time if only the device power down or reboot.";
+        }
+        leaf serial-num {
+            type string;
+            config false;
+            description
+                  "The vendor-specific serial number string for the
+              device.  The preferred value is the serial number
+              string actually printed on the device itself (if
+              present).";
+        }
+	     leaf cpu-utilization {
+          type uint16;
+          config false;
+          description
+            "The cpu utilization of device.The unit is %.";
+        }
+        leaf memory-utilization {
+          type uint16;
+          config false;
+          description
+              "The memory utilization of device.The unit is %.";
+        } 
+	leaf cpu-utilization-high-thr {
+          type uint16;
+         default 100;
+          description
+            "The cpu utilization high alarm threshold of device.The unit is %.";
+        }
+        leaf memory-utilization-high-thr {
+          type uint16;
+          default 80;
+          description
+              "The memory utilization high alarm threshold of device.The unit is %."; 
+	}
+        uses OFSysTimeType;
+        uses OFDevResetType;
+        uses OFDevSaveType;   
+    }
+
+    grouping OFFanType {
+		
+        leaf spdlevel {
+	    config false;
+            type uint32 {
+                range "1..100";
+            }
+            description
+                "Specify the speed level of fan in enforce mode.The unit is %.";
+        }
+		
+        leaf serial-number {
+            config false;
+            type string;
+            description
+              "Specify the identical serial number of current fan card.this 
+              string number is set when the device leaves factory.";
+        }
+		
+        leaf work-state {
+            config false;
+            type enumeration {
+              enum "normal" {
+                value "1";
+              }
+              enum "abnormal" {
+                value "2";
+              }
+            }
+            description
+              "Specify the current state of fan normal(1) means the current fan
+              operate normally; abnormal(2) means the current fan operate abnormally.";
+        }
+		
+        leaf slot {
+            config false;
+            type leafref {
+                path "/of-config:capable-switch/physical-device/card/resource-id";
+            }
+            description
+                "Reference to card resources in the capable-switch.";
+        }
+    }
+	
+    grouping OFPowerType {
+		
+        leaf isexist {
+            config false;  
+            type enumeration {
+                enum "exist" {
+                    value "1";
+                }
+                enum "notexist" {
+                    value "2";
+                }
+            }
+            description
+                "Indicate the power is exist or not exist.";
+        }
+		
+        leaf input-type {
+            config false;
+            type enumeration {
+                enum "unknow" {
+                    value "1";
+                }
+                enum "ac" {
+                    value "2";
+                }
+                enum "dc48" {
+                    value "3";
+                }
+                enum "dc24" {
+                    value "4";
+                }
+            }
+            description
+                "Indicate the input power type.";
+        }
+		
+        leaf slot {
+            config false;
+            type leafref {
+                path "/of-config:capable-switch/physical-device/card/resource-id";
+            }
+            description
+                "Reference to card resources in the capable-switch.";
+        }
+    }
+	
+    grouping OFBannerType {
+        leaf enable {
+           type boolean;
+	   default false;
+           description
+               "Banner enable or disable.";
+        }
+	
+        leaf msgcount {
+            type uint32;
+            description
+                "Count of banner message list.";
+        }
+		
+        list message {
+            key "index";
+  
+            leaf index {             
+		type uint32 {
+                    range "1..10";
+                }
+                description
+                    "Index of message, one banner message upto support 2560 characters, so it needs to create 10 message tables.";
+            }
+		
+            leaf messagebody { 
+		type string {
+                    length "1..256" ;
+                }
+                description
+                    "Banner message input by user.";
+            }
+			
+            leaf headspace {
+	       type uint32 {
+                    range "0..256";
+                }
+                description
+                    "The number of space for the message head.";
+            }
+			
+            leaf tailspace {
+                type uint32 {
+                    range "0..256";
+                }
+                description
+                    "The number of space for the message tail.";
+           }
+        }
+    }
+	
+    grouping physical-device-grouping {
+        container physical-device {
+            description
+                "Including the physical device modules.";
+            container node {
+                uses OFNodeType;
+            }
+            list card {
+                key "resource-id";
+                uses of-config:OFResourceType ;
+                uses OFCardType;
+            }
+            
+            list fan {
+                key "resource-id";
+                uses of-config:OFResourceType ;
+                uses OFFanType;
+            }
+			
+            list power {
+                key "resource-id";
+                uses of-config:OFResourceType ;
+                uses OFPowerType;
+            }
+			
+            container banner {
+                uses OFBannerType;
+            }
+        }    
+        
+    }
+
+    grouping opt-module-grouping {
+        container opt-module {
+            description
+               "The specified attributes of optical module.";
+            leaf opt-connector-type {
+                type connector-type;
+                config false;
+                description
+                   "The connector value indicates the external optical 
+                    or electrical cable connector provided as the media interface";
+            }
+            leaf opt-single-double {
+                type fiber-type;
+                config false;
+                description
+                   "The type of fiber:single or double";
+            }
+            leaf opt-rx-wave-length {
+                type opt-wave-length-type;
+                config false;
+                description
+                   "The receive wavelength.";
+            }
+            leaf opt-tx-wave-length {
+                type opt-wave-length-type;
+                config false;
+                description
+                    "The transmit wavelength.";
+            }
+            leaf opt-bit-rate {
+                type uint32;
+                config false;
+                description
+                   "The nominal bit rate (BR, nominal) is specified in units of KBits/s.";
+            }
+            leaf opt-distance {
+                type uint32;
+                config false;
+                description
+                   "The optDistance is specified in units of Meter";
+            }
+            leaf opt-rx-power {
+                type int32;
+                config false;
+                description
+                    "The power is specified in units of dBm.";
+            }
+            leaf opt-tx-power {
+                type int32;
+                config false;
+                description
+                    "The power is specified in units of dBm.";
+            }
+            leaf opt-temperature {
+                type uint32;
+                config false;
+                description
+                    "unit:1 ℃";
+            }
+            leaf opt-bias-current {
+                type uint32;
+                config false;
+                description
+                    "The transmit bias current is specified in units of mA.";
+            }
+            leaf opt-voltage {
+                type uint32;
+                config false;
+                description
+                    "The optVoltage is specified in units of V.";
+            }
+            leaf opt-sfp-present {
+                type sfp-present-type;
+                config false;
+                description
+                    "The status of optical module present.The status includes present,notPresent or notSupport";
+            }
+            leaf opt-module-type {
+                type opt-module-type;
+                config false;
+                description
+                    "The type of optical module according to package type.";
+            }
+            leaf opt-media-type {
+                type opt-media-type;
+                config false;
+                description
+                    "The media type of optical module,singleMode or multiMode.";
+            }
+
+            leaf opt-laser-status {
+                type opt-laser-status-type;
+                config false;
+                description
+                    "The laser status of optical module.shutdown or open.";
+            }
+            leaf opt-ddm-support {
+                type opt-ddm-support-type;
+                config false;
+                description
+                    "The support condition of ddm.support or notSupport.";
+            }
+            leaf opt-vendor-name {
+                type string;
+                config false;
+                description
+                    "The vendor name shall be the full name of the corporation or
+                    a commonly accepted abbreviation of the name of the corporation.";
+            }
+            leaf opt-vendor-pn {
+                type string;
+                config false;
+                description
+                    "The vendor part number (vendor PN).";
+            }
+            leaf opt-vendor-sn {
+                type string;
+                config false;
+                description
+                    "The vendor serial number (vendor sn).";
+            }
+            leaf opt-vendor-reversion {
+                type string;
+                config false;
+                description
+                    "The vendor revision number (vendor rev).";
+            }
+            uses OFAlarmMaskType;
+
+            leaf opt-tx-power-high-thr{
+                type int32{
+                  range "-40..9";
+                }
+                description
+                    "The power threshold is specified in units of dBm.";
+            }
+            leaf opt-tx-power-low-thr{
+                type int32{
+                  range "-40..9";
+                }              
+                description
+                    "The power threshold is specified in units of dBm.";
+            }
+            leaf opt-rx-power-high-thr{
+                type int32{
+                  range "-40..9";
+                }
+                description
+                    "The power threshold is specified in units of dBm.";
+            }
+            leaf opt-rx-power-low-thr{
+                type int32{
+                  range "-40..9";
+                } 
+                description
+                    "The power threshold is specified in units of dBm.";
+            }            
+            leaf opt-temperature-high-thr {
+                type int32{
+                  range "-40..125";
+                } 
+                description
+                    "unit:1 ℃";
+            }    
+            leaf opt-bias-current-high-thr {
+                type uint32{
+                  range "0..131";
+                }
+                description
+                    "The transmit bias current threshold is specified in units of mA.";
+            } 
+          }                
+	   }
+
+    grouping OFAlarmMaskType {
+      leaf alarm-mask {
+        type boolean;
+        description "Alarm mask configuration by port position.true means open alarm mask";
+        default "false";
+      }
+    }
+
+    grouping port-attributes {
+      leaf port-type {
+        type port-type;
+        config false;
+        description
+        "The type of interface.optical or electrical.";
+      }
+      leaf alarm-inverse-mode {
+        type alarm-inverse-mode-type;
+        default "automatic";
+      }
+      uses OFAlarmMaskType;
+    }
+
+  augment "/of-config:capable-switch/of-config:logical-switches" {
+    uses manage-vlan-group;
+  }
+
+  augment "/of-config:capable-switch" {
+      uses physical-device-grouping;
+  }
+
+  augment "/of-config:capable-switch/of-config:resources/of-config:port" {
+      uses opt-module-grouping;
+  } 
+
+  augment "/of-config:capable-switch/of-config:resources/of-config:port" {
+      uses port-attributes;
+  } 
+}

--- a/CMCC-SPTN-SBI-Yang-20190723/of-config-1.2-sptn-event.yang
+++ b/CMCC-SPTN-SBI-Yang-20190723/of-config-1.2-sptn-event.yang
@@ -1,0 +1,63 @@
+module of-config-1.2-sptn-event {
+	namespace 'http://chinamobile.com.cn/sdn/sptn/sbi/schema/event';
+	prefix "sptn-event";
+
+	import of-config-1.2 { prefix of-config; }
+    import ietf-yang-types { prefix yang-types; } 
+	import of-config-1.2-sptn-alarm { prefix sptn-alm; }
+	
+	organization "SPTN Working Group";
+	contact "SPTN OpenFlow Extensions";
+	description "SPTN EVENT Yang Module";
+
+	revision "2019-06-06" {
+	description "initial";
+	reference "sptn openflow extensions draft";
+	}
+  
+    /*
+    * Groupings
+    */    
+    grouping event {
+		uses "of-config:OFResourceType" {
+			description "Resource-id of the resource raising the event - port, MEG, etc." ;
+		}  
+		
+		leaf SequenceNo {
+			type uint32 {
+			range "1..4294967295";
+			}
+		}
+		leaf eventcode {
+			type uint32 ;
+			description "event code" ;
+		}
+		leaf severity {
+			type "sptn-alm:severity-classification";
+			description "severity classification" ;
+		}
+		leaf timestamp {
+			type "yang-types:timestamp";
+			description "the timestamp is the number of seconds since 2000/01/01 00:00:00" ;
+		}
+		leaf description {
+			type string {
+			length "1..255" ;
+			}
+			description "the event description" ;
+		}
+		description "event";
+    }
+  
+    /*
+    * Notifications
+    */    
+    notification event-notification {
+        container event {
+            uses event;
+            description "event-notification";
+        }
+        description "event-notification";
+    }
+
+}

--- a/CMCC-SPTN-SBI-Yang-20190723/of-config-1.2-sptn-lag.yang
+++ b/CMCC-SPTN-SBI-Yang-20190723/of-config-1.2-sptn-lag.yang
@@ -8,7 +8,7 @@ module of-config-1.2-sptn-lag {
   contact "SPTN OpenFlow Extensions";
   description "SPTN LAG Yang Module";
 
-  revision "2019-06-06" {
+  revision "2019-11-18" {
     description "initial";
     reference "sptn openflow extensions draft";
   }
@@ -87,75 +87,81 @@ module of-config-1.2-sptn-lag {
       }
   }
 
-  container sptn-lag {
-    description
-      "The lag attibutes list.";
-      list lag {
-        key "lag-id";
-      
-        description
-          "";
-        uses OFLagType;
-      }
-    
-  }
-
   grouping OFLagType {
-    leaf lag-id {
-      type uint32;
-    
-      description
-        "The lag group id.";
-    }
-    leaf description {
-      type string;
-    
-      description
-        "The description of lag.";
-    }
+	list lag {
+		key "resource-id";
 
-    leaf-list port {
-        type leafref {
-          path "/of-config:capable-switch/of-config:resources/of-config:port/of-config:resource-id";
-        }
-        description
-        "A resource identifier of a port of the OpenFlow Capable
-        Switch that the OpenFlow Logical Switch has exclusive access to.
+		description
+			"";
+		uses of-config:OFResourceType;
+	  
+		leaf lag-id {
+		  type uint32;
+		
+		  description
+			"The lag group id.";
+		}
+		
+		leaf openflow-port {
+		  type uint32;
+		  config false;
+		  description
+			"The lag openflow port.";
+		}	
+		
+		leaf description {
+		  type string;
+		
+		  description
+			"The description of lag.";
+		}
 
-        Elements in this list MUST be unique. This means each
-        port element can only be referenced once.";
-    }
-    leaf lag-policy {
-      type lag-policy-type;
-    
-      description
-        "The lag policy.";
-    }
-    leaf lag-mode {
-      type lag-mode-type ;
-    
-      description
-        "The lag mode type.";
-    }
-    leaf lag-lacp-mode {
-      type lag-lacp-mode-type;
-    
-      description
-        "manual,static";
-    }
-    leaf lag-reverse-mode {
-      type lag-reverse-type;
-    
-      description
-        "reverse,unreverse";
-    }
-    leaf lag-status {
-      type lag-status-type;
-    
-      description
-        "up,down";
-    }
+		leaf lag-policy {
+		  type lag-policy-type;
+		
+		  description
+			"The lag policy.";
+		}
+		leaf lag-mode {
+		  type lag-mode-type ;
+		
+		  description
+			"The lag mode type.";
+		}
+		leaf lag-lacp-mode {
+		  type lag-lacp-mode-type;
+		
+		  description
+			"manual,static";
+		}
+		leaf lag-reverse-mode {
+		  type lag-reverse-type;
+		
+		  description
+			"reverse,unreverse";
+		}		
+		leaf-list port {
+			type leafref {
+			  path "/of-config:capable-switch/of-config:resources/of-config:port/of-config:resource-id";
+			}
+			description
+			"A resource identifier of a port of the OpenFlow Capable
+			Switch that the OpenFlow Logical Switch has exclusive access to.
 
-
+			Elements in this list MUST be unique. This means each
+			port element can only be referenced once.";
+		}
+		leaf lag-status {
+		  type lag-status-type;
+		
+		  description
+			"up,down";
+		}
+	}
   }
+  
+  	augment "/of-config:capable-switch/of-config:resources" {
+      uses OFLagType;
+	}  
+
 }

--- a/CMCC-SPTN-SBI-Yang-20190723/of-config-1.2-sptn-link-oam.yang
+++ b/CMCC-SPTN-SBI-Yang-20190723/of-config-1.2-sptn-link-oam.yang
@@ -9,7 +9,7 @@ module of-config-1.2-sptn-link-oam {
   contact "SPTN OpenFlow Extensions";
   description "SPTN Device Yang Module";
 
-  revision "2019-06-06" {
+  revision "2019-12-27" {
     description "initial";
     reference "sptn openflow extensions draft";
   }
@@ -74,28 +74,34 @@ module of-config-1.2-sptn-link-oam {
       }
   }
 
-  typedef loopback-type {
+  typedef loopback-cmd-type {
+    type enumeration {
+        enum "initiatingLoopback" {
+          value 1;
+        } 
+        enum "terminatingLoopback" {
+          value 2;
+        } 
+      }
+  }
+  
+    typedef loopback-status-type {
     type enumeration {
         enum "noLoopback" {
           value 1;
         }
-        enum "initiatingLoopback" {
-          value 2;
-        } 
         enum "remoteLoopback"{
+          value 2;
+        }
+        enum "localLoopback"{
           value 3;
         }
-        enum "terminatingLoopback" {
-          value 4;
-        } 
-        enum "localLoopback"{
-          value 5;
-        }
         enum "unknown" {
-          value 6;
+          value 4;
         } 
       }
   }
+
 
   typedef handing-type {
     type enumeration {
@@ -209,11 +215,17 @@ module of-config-1.2-sptn-link-oam {
     container oam-loopback {
       description
         "The oam loopback information.";
-      leaf loopback-status {
-        type loopback-type;
+      leaf loopback-cmd {
+        type loopback-cmd-type;
       
         description
-          "The loopback status can be configed.";
+          "The loopback  command.";
+      }
+      leaf loopback-status {
+        type loopback-status-type;
+		config false;
+        description
+          "The loopback status.";
       }
       leaf rx-handing {
         type handing-type;

--- a/CMCC-SPTN-SBI-Yang-20190723/of-config-1.2-sptn-port-ext.yang
+++ b/CMCC-SPTN-SBI-Yang-20190723/of-config-1.2-sptn-port-ext.yang
@@ -8,7 +8,7 @@ module of-config-1.2-sptn-port-ext {
   contact "SPTN OpenFlow Extensions";
   description "SPTN Port Extensions Yang Module";
 
-  revision "2019-06-11" {
+  revision "2019-12-27" {
     description "initial";
     reference "sptn openflow extensions draft";
   }
@@ -132,6 +132,39 @@ module of-config-1.2-sptn-port-ext {
       }  
     } 
   }
+  
+  grouping tdm-e1-status-grouping {
+    container tdm-e1-status {
+      description
+        "The tdm performance status.";
+      leaf es {
+        type uint64;
+        config false;
+        description
+          "The error seconds.";
+      }
+      leaf ses {
+        type uint64;
+        config false;
+        description
+          "The severely error seconds.";
+      }
+
+      leaf uas {
+        type uint64;
+        config false;
+        description
+          "The unavailable seconds."; 
+      }
+
+      leaf cv {
+        type uint64;
+        config false;
+        description
+          "The Code Violation."; 
+      }
+    }
+  }
 
   grouping tdm-grouping {
     container tdm {
@@ -180,7 +213,7 @@ module of-config-1.2-sptn-port-ext {
         description
           "";
       }
-      
+      uses tdm-status-grouping;
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -19,3 +19,12 @@ This project defines the YANG files used in SPTN (Software defined Packet Transp
 This repository is created to support the China Mobile (CMCC) SPTN project. 
 
 Any questions about this repository, please contact wangminxue@chinamobile.com, xuyunbin@caict.ac.cn or zhaoxing@caict.ac.cn.
+
+2019年12月30日 提供最新版yang文件。
+与之前相比：
+1，增加了《of-config-1.2-sptn-event.yang》。
+2，删除了《of-config-1.2-sptn-vpls.yang》。
+3，《of-config-1.2-sptn-clock.yang》中的leaf-list system-clock-source-priority-list 增加 ordered-by user;
+4，《of-config-1.2-sptn-lag.yang》将 lag 节点放入 "/of-config:capable-switch/of-config:resources"中，在 lag 节点中 加入 leaf openflow-port。
+5，《of-config-1.2-sptn-link-oam.yang》将 loopback-status 拆分为 loopback-cmd 和 loopback-status。
+6，《of-config-1.2-sptn-port-ext.yang》在 tdm 节点下增加 tdm-e1-status。用于控制器查询 TDM业务性能数据。

--- a/yang-20191230/of-config-1.2-sptn-alarm.yang
+++ b/yang-20191230/of-config-1.2-sptn-alarm.yang
@@ -1,0 +1,173 @@
+module of-config-1.2-sptn-alarm {
+ namespace 'http://chinamobile.com.cn/sdn/sptn/sbi/schema/alm' ;
+
+ prefix sptn-alm ;
+
+ import of-config-1.2 { prefix of-config; }
+ import ietf-yang-types { prefix yang-types; }
+ import of-config-1.2-sptn-oam { prefix sptn-oam; }
+
+ organization "SPTN Working Group";
+ contact "SPTN OpenFlow Extensions";
+
+ description
+ "This version of this YANG Module is made in 2018-05-09. modify alarm-shield into alarm-mask on the version of 2018-05-02.";
+
+ revision 2018-05-09 {
+  description
+  "This version of this YANG Module is made in 2016/03/29.";
+}
+
+
+typedef severity-classification {
+  type enumeration {
+    enum critical {
+      value 1 ;
+      description "severity-classification critical";
+    }
+    enum major {
+      value 2 ;
+      description "severity-classification major";
+    }
+    enum minor {
+      value 3 ;
+      description "severity-classification minor";
+    }
+    enum warning {
+      value 4 ;
+      description "severity-classification warning";
+    }
+  }
+  description "severity classification";
+} 
+typedef alarm-status {
+  type enumeration {
+    enum occurred {
+      value 1 ;
+      description "alarm occurred";
+    }
+    enum cleared {
+      value 2 ;
+      description "alarm cleared";
+    }
+  }
+  description "alarm status";
+}
+
+grouping alarm-report {
+  description "Common elements for alarm lists";
+
+  uses "of-config:OFResourceType" {
+   description "Resource-id of the resource raising the alarm - port, MEG, etc." ;
+ }      
+
+ list almCodelist {
+  key "almcode";
+  leaf SequenceNo {
+    type uint32 {
+      range "1..4294967295";
+    }
+  }
+  leaf almcode {
+    type uint32 ;
+    description "alarm code" ;
+  }
+  leaf severity {
+    type severity-classification ;
+    description "severity classification" ;
+  }
+  leaf timestamp {
+    type "yang-types:timestamp";
+    description "the timestamp is the number of seconds since 2000/01/01 00:00:00" ;
+  }
+  leaf alarm-status {
+    type alarm-status ;
+    description "alarm status" ;
+  }
+  leaf description {
+    type string {
+      length "1..255" ;
+    }
+    description "the alarm description" ;
+  }
+}
+}
+
+
+notification current-alarm-report {
+
+  list alarmReportlist {
+    key "OFLogicalSwitchId resource-id";
+    leaf OFLogicalSwitchId {
+      type "of-config:OFConfigId" ;
+    }
+    uses alarm-report ;
+  }
+  }  // notification
+
+  notification protection-status-report {
+
+    leaf SequenceNo {
+      type uint32 {
+        range "1..4294967295";
+      }
+    }
+
+    uses "of-config:OFResourceType" {
+     description "Resource-id of the protection group." ;
+   }      
+
+   leaf OFLogicalSwitchId {
+    type "of-config:OFConfigId" ;
+  }
+
+  uses "sptn-oam:protection-status" ;
+
+  leaf lastWatchportOfSwitcher {
+    type uint32 ;
+  }
+
+  leaf currentWatchportOfSwitcher {
+    type uint32 ;
+  }
+
+  }  // notification
+
+  grouping current-alarm-group {
+    container current-alarm {
+      description "Current alarms for this logical switch";
+      config false;
+      list alarmlist {
+        key "resource-id";
+        uses alarm-report;
+      }
+    } // container
+
+    container alarm-management {
+      description
+        "alarm management functions.";
+
+      list alarmConfiglist {
+        description
+        "Alarm mask configuration by alarm type.";
+        key "almcode";
+        leaf almcode {
+            type uint32 ;
+              description "alarm code";
+            }
+
+        leaf alarm-mask {
+            type boolean;
+            default "false";
+        }
+      }
+    }
+  }
+
+  augment "/of-config:capable-switch/of-config:logical-switches/of-config:switch" {
+      uses current-alarm-group;
+    
+
+  } // augment
+
+} // module

--- a/yang-20191230/of-config-1.2-sptn-ces.yang
+++ b/yang-20191230/of-config-1.2-sptn-ces.yang
@@ -1,0 +1,136 @@
+module of-config-1.2-sptn-ces {
+    namespace 'http://chinamobile.com.cn/sdn/sptn/sbi/schema/sptn/ces' ;
+    prefix "sptn-ces";
+
+    import of-config-1.2 { 
+        prefix of-config; 
+    }
+
+    organization "SPTN Working Group";
+    
+    description "SPTN CES Yang Module";
+
+    revision "2019-06-06" {
+       description "initial";
+    }
+
+    typedef encapsulation-type {
+        type enumeration {
+         enum "raw" {
+           value 0;
+           description "raw";
+         }
+         enum "tag" {
+           value 1;
+           description "tag";
+         }
+       }
+    }
+
+    typedef role-type{
+        type enumeration{
+            enum root{
+                value 0;
+            }
+            enum leaf{
+                value 1;
+            }
+        }
+    }
+
+    typedef cos-type {
+        type enumeration{
+            enum cs7{
+                value 1;
+            }
+            enum cs6{
+                value 2;
+            }
+            enum ef{
+                value 3;
+            }
+        }
+    }
+
+    typedef ces-encapsulation-type {
+        type enumeration{
+            enum SAToP{
+                value 1;
+            }
+            enum CESoPSN{
+                value 2;
+            }
+        }
+    }
+
+    grouping ces-grouping {
+         list ces {
+            key "resource-id";
+        
+            description
+                "";
+            uses of-config:OFResourceType;
+
+            leaf name {
+                type string;
+            
+                description
+                    "";
+            }
+
+            leaf ces-id {
+                type uint32;
+            
+                description
+                    "The logical port id related to the openflow table.";
+            }
+            leaf uni-port {
+                type leafref {
+                    path "/of-config:capable-switch/of-config:resources/of-config:port/of-config:resource-id";
+                }
+                description
+                    "The E1 port path. ";
+            }
+
+            leaf timeslot {
+                type uint32;
+            
+                description
+                    "";
+            }
+
+            leaf rtp-enable {
+                type boolean;
+            
+                description
+                    "true:enable false:disable";
+            }
+
+            leaf encapsulation-type {
+                type ces-encapsulation-type;
+            
+                description
+                    "";
+            }
+            leaf jitter-buffer {
+                type uint32;
+            
+                description
+                    "The size of jitter buffer.";
+            }
+            leaf payload-size {
+                type uint16;
+            
+                description
+                    "payload size.";
+            }
+        }
+
+    }
+
+    container sptn-ces {
+        description
+            "";
+        uses ces-grouping;
+    } 
+ }

--- a/yang-20191230/of-config-1.2-sptn-clock.yang
+++ b/yang-20191230/of-config-1.2-sptn-clock.yang
@@ -1,0 +1,316 @@
+module of-config-1.2-sptn-clock {
+  namespace 'http://chinamobile.com.cn/sdn/sptn/sbi/schema/clock'  ;
+  prefix "sptn-clock";
+
+  import of-config-1.2 { prefix of-config; }
+
+  organization "SPTN Working Group";
+  contact "SPTN OpenFlow Extensions";
+  description "SPTN Device Yang Module";
+
+  revision "2019-06-06" {
+    description "initial";
+    reference "sptn openflow extensions draft";
+  }
+
+  typedef clock-source-select-mode-type {
+    type enumeration {
+        enum "auto" {
+          value 1;
+        }
+        enum "local" {
+          value 2;
+        }
+        enum "ext2M" {
+          value 3;
+        } 
+        enum "freerun" {
+          value 4;
+        } 
+      }
+  }
+
+  typedef bits-type {
+    type enumeration {
+      enum KBPS {
+        description "none";
+      }
+      enum KHZ {
+        description "none";
+      }
+    }
+    description "none";
+  }
+
+  typedef run-mode-type {
+      type enumeration {
+        enum "unknown" {
+          value 1;
+        }
+        enum "lockEx2M" {
+          value 2;
+        } 
+        enum "lockLocal" {
+          value 3;
+        } 
+        enum "freerun" {
+          value 4;
+        }
+        enum "holdover" {
+          value 5;
+        }
+        enum "preLocked"{
+          value 6;
+        }
+        enum "lostLocked" {
+          value 7;
+        }
+      }
+  }
+
+  typedef reversion-mode-type {
+    type enumeration {
+      enum "REVERTIVE" {
+        value 1;
+      }
+      enum "NON-REVERTIVE" {
+        value 2;
+      } 
+    }
+  }
+
+  typedef switch-type {
+   type enumeration {
+      enum "Lockout" {
+        value 1;
+      }
+      enum "Manual switch" {
+        value 2;
+      }
+      enum "Forced switch" {
+        value 3;
+      }
+    }
+  }
+
+  typedef clock-quality-level {
+    type enumeration {
+      enum QL_PRC {
+        description "none";
+      }
+      enum QL_SSU_A {
+        description "none";
+      }
+      enum QL_SSU_B {
+        description "none";
+      }
+      enum QL_EEC1 {
+        description "none";
+      }
+      enum QL_DNU {
+        description "none";
+      }
+      enum QL_PRTC {
+        description "none";
+      }
+      enum QL_ePRTC {
+        description "none";
+      }
+      enum QL_eEEC {
+        description "none";
+      }
+      enum QL_NONE {
+        description "none";
+      }               
+    }
+    description "Use the clock quality levels listed in section 5.4.1 of G.781 (08/2017). The corresponding SSM codes and enhanced SSM codes for SyncE refer to table 11-7 and table 11-8 of G.8264 (08/2017)";
+  }
+  
+  typedef ssm-mode-type {
+    type enumeration {
+      enum MANUAL {
+        description "none";
+      }
+      enum AUTOMATIC {
+        description "none";
+      }
+    }
+    description "none";
+  }
+
+  grouping clock-grouping {
+    container clock {
+      description
+        "";
+        leaf ssm-output-enable-status {
+          type boolean;
+        
+          description
+            "Indicate whether to send SSM messages or not.";
+        }
+        leaf ssm-in-information {
+          type clock-quality-level;
+        
+          description
+            "Current input SSM quality levels used by the port. The SSM quality level can be set manually or automatically. The port should have SSM quality levels for input and output respectively. ";
+        }
+        leaf ssm-out-information {
+          type clock-quality-level;
+        
+          description
+            "Current output SSM quality levels used by the port. The SSM quality level can be set manually or automatically. The port should have SSM quality levels for input and output respectively. ";
+        }
+        leaf ssm-mode {
+          type ssm-mode-type;
+         
+          description
+            "Indicate whether to use manual or automatic input and output SSM quality levels. SSM mode should be set for input and output respectively.";
+        }
+        leaf ssm-configuration {
+          type clock-quality-level;
+          description "The input and output SSM quality levels set manually. The SSM quality levels should be manually configurable for input and output respectively.";
+        }
+      
+    }
+  }
+
+  grouping ext2M-clock-grouping {
+      leaf external-port-enable-status {
+        type boolean;
+      
+        description
+          "The enable status of external port.";
+      }
+      leaf bits-type-input {
+        type bits-type;
+      
+        description
+          "The input type of this port, such as 2048kb/s or 2048kHz.";
+      }
+      leaf bits-type-output {
+        type bits-type;
+      
+        description
+          "The output type of this port, such as 2048kb/s or 2048kHz.";
+      }
+      leaf ssm-sa-bit {
+        type uint64;
+      
+        description
+          "Indicate which sa-bit bits are used for carrying input and output SSM quality levels. The port should have sa-bit bits for input and output respectively.";
+      }
+      leaf ssm-out-threshold{
+        type clock-quality-level;
+        config false;
+        description "The external port stops transmitting when the SSM quality level is lower than the threshold.";
+      }
+      leaf ssm-information{
+        type clock-quality-level;
+        description "Current input and output SSM quality levels used by the port. The port should have SSM quality levels for input and output respectively.";
+      }
+      leaf ssm-mode {
+        type ssm-mode-type;
+      
+        description "Indicate whether to use manual or automatic input and output SSM quality levels. SSM mode should be set for input and output respectively.";
+      }
+      leaf ssm-configuration{
+        type clock-quality-level;
+        description
+          "The manual ssm information.";
+      }
+  }
+
+  container global-clock {
+      description
+        "The global attributes of clock.";
+      leaf clock-source-sel-mode {
+         type clock-source-select-mode-type;
+       
+         description
+           "auto,local,ext2M,freerun";
+      } 
+      leaf-list port {
+        type leafref {
+          path "/of-config:capable-switch/of-config:resources/of-config:port/of-config:resource-id";
+        }
+        description "The port can be configed when the clock source select mode is local";
+      }
+      
+      leaf wait-to-revert-time {
+        type uint16;
+      
+        description
+          "";
+      }
+
+      leaf holdoff-time {
+        type uint16;
+      
+        description
+          "";
+      }
+      leaf-list system-clock-source-priority-list {
+        type string;
+             ordered-by user;
+   
+        description
+          "The list of port priority.";
+      }
+      leaf switch-type {
+        type switch-type;
+      
+        description
+          "The protection switch type.";
+      }
+      leaf ssm-enable-status {
+        type boolean;
+      
+        description
+          "The ssm enable,true:enable false:disable";
+      }
+      leaf unk-status {
+        type boolean;
+      
+        description
+          "The device unk ssm enable";
+      }
+
+      container clock-status {
+        description
+          "The atrributes of clock status.";
+        leaf run-mode {
+          type run-mode-type;
+          config false;
+          description
+              "";
+        }
+        leaf reversion-mode {
+          type reversion-mode-type;
+          config false;
+          description
+          "The protection switch reversion mode.";
+        }
+
+        leaf current-source-port-id {
+          type leafref {
+            path "/of-config:capable-switch/of-config:resources/of-config:port/of-config:resource-id";
+          }
+          config false;
+          description "The selected eth clock.";
+        }
+        
+      }
+
+      container ext2M-clock {
+        description
+          "The atrributes of ext2M clock.";
+        uses ext2M-clock-grouping;
+      }
+      
+  }
+
+  augment "/of-config:capable-switch/of-config:resources/of-config:port" {
+      uses clock-grouping;
+  } 
+
+}

--- a/yang-20191230/of-config-1.2-sptn-device.yang
+++ b/yang-20191230/of-config-1.2-sptn-device.yang
@@ -1,0 +1,987 @@
+module of-config-1.2-sptn-device {
+  namespace 'http://chinamobile.com.cn/sdn/sptn/sbi/schema/device' ;
+  prefix "sptn-device";
+
+  import of-config-1.2 { prefix of-config; }
+  import ietf-yang-types { prefix yang; }
+  import ietf-inet-types { prefix inet; }
+
+  organization "SPTN Working Group";
+  contact "SPTN OpenFlow Extensions";
+  description "SPTN Device Yang Module";
+
+  revision "2018-05-09" {
+    description "initial";
+    reference "sptn openflow extensions draft";
+  }
+
+  typedef connector-type {
+        type enumeration {
+            enum "SC" {
+                value 1;
+            }
+            enum "LC" {
+                value 2;
+            }
+       }
+    }
+    typedef fiber-type {
+        type enumeration {
+            enum "single" {
+                value 1;
+            }
+            enum "double" {
+                value 2;
+            }
+       }
+    }
+
+    typedef sfp-present-type {
+        type enumeration {
+            enum "present" {
+                value 1;
+            }
+            enum "notPresent" {
+                value 2;
+            }
+            enum "notSupport" {
+                value 3;
+            }
+       }
+    }
+    typedef opt-module-type {
+        type enumeration {
+            enum "SFP" {
+                value 1;
+            }
+            enum "SFF" {
+                value 2;
+            }
+            enum "XFF" {
+                value 3;
+            }
+            enum "SFP PLUS" {
+                value 4;
+            }
+            enum "XFP" {
+                value 5;
+            }
+            enum "XFP-E" {
+                value 6;
+            }
+            enum "GBIC" {
+                value 7;
+            }
+            enum "XPak" {
+                value 8;
+            }
+            enum "X2" {
+                value 9;
+            }
+            enum "DWDM-SFP" {
+                value 10;
+            }
+            enum "QSFP" {
+                value 11;
+            }
+            enum "300 pin XBI" {
+                value 12;
+            }
+            enum "Unknown" {
+                value 13;
+            }
+       }
+    }
+
+    typedef opt-media-type {
+        type enumeration {
+            enum "singleMode" {
+                value 1;
+            }
+            enum "multiMode" {
+                value 2;
+            }
+       }
+    }
+    typedef opt-laser-status-type {
+        type enumeration {
+            enum "shutdown" {
+                value 1;
+            }
+            enum "open" {
+                value 2;
+            }
+       }
+    }
+
+    typedef opt-ddm-support-type {
+        type enumeration {
+            enum "support" {
+                value 1;
+            }
+            enum "notSupport" {
+                value 2;
+            }
+       }
+    }
+
+    typedef opt-wave-length-type {
+        type enumeration {
+            enum "wavelength_1310nm" {
+                value 1;
+            }
+            enum "wavelength_1550nm" {
+                value 2;
+            }
+            enum "wavelength_850nm" {
+                value 3;
+            }
+            enum "wavelength_1490nm" {
+                value 4;
+            }
+            enum "wavelength_1530nm" {
+                value 5;
+            }
+            enum "wavelength_1610nm" {
+                value 6;
+            }
+            enum "wavelength_unknown" {
+                value 7;
+            }			
+        }
+    }
+
+    typedef port-type {
+        type enumeration {
+            enum "optical" {
+                value 1;
+            }
+            enum "electrical" {
+                value 2;
+            }
+       }
+    }
+
+    typedef node-type {
+        type enumeration {
+            enum "CPE" {
+                value 1;
+            }
+            enum "HUB" {
+                value 2;
+            }
+            enum "Unknown" {
+                value 3;
+            }
+       }
+    }
+
+    typedef admin-status-type {
+        type enumeration {
+          enum "up" {
+              value 1;
+          }
+          enum "down" {
+              value 2;
+          }
+       }
+    }
+
+    typedef oper-status-type {
+        type enumeration {
+          enum "null" {
+              value 1;
+          }
+          enum "initing" {
+              value 2;
+          }
+          enum "upgrating" {
+              value 3;
+          }
+          enum "running" {
+              value 4;
+          }
+          enum "exception" {
+              value 5;
+          }
+       }
+    }
+
+    typedef master-mode-type {
+        type enumeration {
+          enum "master" {
+              value 1;
+          }
+          enum "slave" {
+              value 2;
+          }
+          enum "none" {
+              value 3;
+          }
+       }
+    }
+
+    typedef dev-oper-status-type {
+        type enumeration {
+            enum "up" {
+                value 1;
+            }
+            enum "down" {
+                value 2;
+            }
+       }
+    }
+
+    typedef reset-comoman-type {
+        type enumeration {
+            enum "none" {
+                value 1;
+            }
+            enum "reset" {
+                value 2;
+            }
+       }
+    }
+
+    typedef save-command-type {
+        type enumeration {
+            enum "none" {
+                value 1;
+            }
+            enum "save" {
+                value 2;
+            }
+       }
+    }
+
+    typedef alarm-inverse-mode-type {
+      type enumeration {
+        enum "un-inverse" {
+            value 0;
+            description "Disable alarm-inverse function.you can't enable port alram-inverse ";
+        }
+        enum "automatic" {
+            value 1;
+            description "In automaic mode,you can enable/disable port alram-inverse.
+                  If port isn't used,don't report alarm.when port is used,report alarm normally.";
+        }
+        enum "manual" {
+            value 2;
+            description "In manual mode,you can enable/disable port alram-inverse.
+            Report the inverse alarm status of port.";
+        }
+    }
+} 
+
+
+  grouping manage-vlan-group {
+    container manage-vlan {
+      description
+      "the normal vlan in which packets forward based on L2 mac learning. This 
+      vlan is automaticly created by the switch when powered up. In this
+      vlan, the ip address and default route are configued so that the 
+      switch can connect to the controller, and other deives can use the 
+      vlan as a path to link to controller.";
+
+      leaf vid {
+        type uint32 {
+          range "1..4094";
+        }
+        description
+        "The vid of the vlan, It is predefined by China mobile.";
+      }
+
+      leaf-list port {
+        type leafref {
+          path "/of-config:capable-switch/of-config:resources/of-config:port/of-config:resource-id";
+        }
+        description
+        "A resource identifier of a port of the OpenFlow Capable
+        Switch that the OpenFlow Logical Switch has exclusive access to.
+
+        Elements in this list MUST be unique. This means each
+        port element can only be referenced once.";
+      }
+
+      leaf manage-ip-address {
+        type inet:ip-address;
+        description
+        "Local ip address for the switch. this ip normally got through dhcp server,
+        but the controller can modify it, too.";
+      }
+
+      leaf manage-ip-mask {
+        type uint8 {
+          range "0..32";
+        }
+        description
+        "Ip address mask.";
+      }
+
+      leaf default-route {
+        type inet:ip-address;
+        description
+        "Default route of the switch. this ip normally got through dhcp server,
+        but the controller can modify it, too.";
+      }
+    }
+  }
+
+  grouping OFCardType {
+        leaf slot-num {
+          type uint16;
+          config false;
+          description
+            "The number of the slot.";
+        }
+        leaf card-name {
+          type string;
+          config false;
+          description
+            "The name of the card.";
+        }
+        leaf card-desc {
+          type string;
+          description
+            "The description of the card.";
+        }
+        leaf manufacture-info {
+          type string;
+          config false;
+          description
+            "The manufacture information, for example,the factory information.";
+        }
+        leaf serial-num {
+          type string;
+          config false;
+          description
+              "The vendor-specific serial number string for the
+              card.  The preferred value is the serial number
+              string actually printed on the card itself (if
+              present).";
+        }
+        leaf card-temperature {
+          type string;
+          config false;
+          description
+            "The temperature of the card.";
+        }
+        leaf cpu-utilization {
+          type uint16;
+          config false;
+          description
+            "The cpu utilization of card.The unit is %.";
+        }
+        leaf memory-utilization {
+          type uint16;
+          config false;
+          description
+              "The memory utilization of card.The unit is %.";
+        }
+        leaf cpu-utilization-high-thr {
+          type uint16{
+          range "60..100";
+        }
+         default 80;
+          description
+            "The cpu utilization high alarm threshold of card.The unit is %.";
+        }
+        leaf memory-utilization-high-thr {
+          type uint16{
+            range "60..100";
+          } 
+          default 80;
+          description
+              "The memory utilization high alarm threshold of card.The unit is %.";
+        }   
+        leaf card-temperature-high-thr{
+          type int16{
+            range "-10..60";
+          }
+          default 50;
+          description
+            "The temperature high alarm threshold of the card.The unit is degree Celsius";
+        }
+        leaf card-temperature-low-thr{
+          type int16{
+            range "-10..60";
+          }
+          default 0;
+          description
+            "The temperature high alarm threshold of the card.The unit is degree Celsius";
+        }             
+        leaf oper-status {
+          type oper-status-type;
+          config false;
+          description
+            "The working status of card.";
+        }
+        leaf master-mode {
+          type master-mode-type;
+          config false;
+          description
+              "The master mode, master or slave for main control  or E1 board.";
+        }
+        leaf software-version {
+          type string;
+          config false;
+          description
+              "The vendor-specific software revision string for the
+              card.";
+        }
+        leaf hardware-version {
+          type string ;
+          config false;
+          description
+            "The vendor-specific hardware revision string for the
+              card.  The preferred value is the hardware revision
+              identifier actually printed on the card itself (if
+              present).";
+        }
+        leaf firmware-version {
+          type string;
+          config false;
+          description
+            "The vendor-specific firmware revision string for the
+              card.";
+        }
+        leaf boot-version {
+          type string;
+          config false;
+          description           
+	   "The vendor-specific boot revision string for the card.";
+        }
+        leaf-list port {
+            type leafref {
+                path "/of-config:capable-switch/of-config:resources/of-config:port/of-config:resource-id";
+            }
+            description
+            "Reference to port resources in the Capable Switch.
+            This element associates ports with card.";
+        }
+        uses OFAlarmMaskType;
+    }
+
+    grouping OFSysTimeType {
+        leaf sys-time {
+            type yang:date-and-time;        
+            description
+                "The time of system.The controller can set the system time 
+                 same to the server time.";
+        }
+    }
+
+    grouping OFDevResetType {
+        leaf reset-command {
+            type reset-comoman-type;
+            description
+                "The command of reset the device.";
+        }
+    }
+
+    grouping OFDevSaveType {
+        leaf save-command {
+            type save-command-type;
+            description
+                "The command of reset the device.";
+        }
+    }
+
+
+    grouping OFNodeType {
+        leaf type {
+            type node-type;
+            
+            description
+                "The device type,HUB or CPE (if known) or unknown.";
+        }
+        leaf name {
+            type string {
+                length "1..32";
+            }
+            config false;
+            description
+                "The device name of the vendor specific.";
+        }
+        leaf description {
+            type string;
+            description
+                "A textual description of device.";
+        }
+        leaf vendor {
+            type string;
+            config false;
+            description
+                "The name of the vendor.";
+        }
+        leaf firmware-rev {
+            type string;
+            config false;
+            description
+                "The vendor-specific firmware revision string for the
+              device.";
+        }
+
+        leaf software-rev {
+            type string;
+            config false;
+            description
+                "The vendor-specific software revision string for the
+              device.";
+        }
+        leaf hardware-rev {
+            type string;
+            config false;
+            description
+                "The vendor-specific hardware revision string for the
+              device.  The preferred value is the hardware revision
+              identifier actually printed on the device itself (if
+              present)";
+        }
+        leaf boot-version {
+            type string;
+            config false;
+            description
+                "The boot version.";
+        }
+        leaf oper-status {
+            type dev-oper-status-type;
+            config false; 
+            description
+                "The working status of the device,up or down.";
+        }
+        leaf mac-addr {
+            type yang:mac-address;
+            config false;
+            description
+                "The Mac-address of the device.";
+        }
+        leaf run-time {
+            type uint32;
+            config false;
+            description
+                "The running time of device since power on. Device update this run-time if only the device power down or reboot.";
+        }
+        leaf serial-num {
+            type string;
+            config false;
+            description
+                  "The vendor-specific serial number string for the
+              device.  The preferred value is the serial number
+              string actually printed on the device itself (if
+              present).";
+        }
+	     leaf cpu-utilization {
+          type uint16;
+          config false;
+          description
+            "The cpu utilization of device.The unit is %.";
+        }
+        leaf memory-utilization {
+          type uint16;
+          config false;
+          description
+              "The memory utilization of device.The unit is %.";
+        } 
+	leaf cpu-utilization-high-thr {
+          type uint16;
+         default 100;
+          description
+            "The cpu utilization high alarm threshold of device.The unit is %.";
+        }
+        leaf memory-utilization-high-thr {
+          type uint16;
+          default 80;
+          description
+              "The memory utilization high alarm threshold of device.The unit is %."; 
+	}
+        uses OFSysTimeType;
+        uses OFDevResetType;
+        uses OFDevSaveType;   
+    }
+
+    grouping OFFanType {
+		
+        leaf spdlevel {
+	    config false;
+            type uint32 {
+                range "1..100";
+            }
+            description
+                "Specify the speed level of fan in enforce mode.The unit is %.";
+        }
+		
+        leaf serial-number {
+            config false;
+            type string;
+            description
+              "Specify the identical serial number of current fan card.this 
+              string number is set when the device leaves factory.";
+        }
+		
+        leaf work-state {
+            config false;
+            type enumeration {
+              enum "normal" {
+                value "1";
+              }
+              enum "abnormal" {
+                value "2";
+              }
+            }
+            description
+              "Specify the current state of fan normal(1) means the current fan
+              operate normally; abnormal(2) means the current fan operate abnormally.";
+        }
+		
+        leaf slot {
+            config false;
+            type leafref {
+                path "/of-config:capable-switch/physical-device/card/resource-id";
+            }
+            description
+                "Reference to card resources in the capable-switch.";
+        }
+    }
+	
+    grouping OFPowerType {
+		
+        leaf isexist {
+            config false;  
+            type enumeration {
+                enum "exist" {
+                    value "1";
+                }
+                enum "notexist" {
+                    value "2";
+                }
+            }
+            description
+                "Indicate the power is exist or not exist.";
+        }
+		
+        leaf input-type {
+            config false;
+            type enumeration {
+                enum "unknow" {
+                    value "1";
+                }
+                enum "ac" {
+                    value "2";
+                }
+                enum "dc48" {
+                    value "3";
+                }
+                enum "dc24" {
+                    value "4";
+                }
+            }
+            description
+                "Indicate the input power type.";
+        }
+		
+        leaf slot {
+            config false;
+            type leafref {
+                path "/of-config:capable-switch/physical-device/card/resource-id";
+            }
+            description
+                "Reference to card resources in the capable-switch.";
+        }
+    }
+	
+    grouping OFBannerType {
+        leaf enable {
+           type boolean;
+	   default false;
+           description
+               "Banner enable or disable.";
+        }
+	
+        leaf msgcount {
+            type uint32;
+            description
+                "Count of banner message list.";
+        }
+		
+        list message {
+            key "index";
+  
+            leaf index {             
+		type uint32 {
+                    range "1..10";
+                }
+                description
+                    "Index of message, one banner message upto support 2560 characters, so it needs to create 10 message tables.";
+            }
+		
+            leaf messagebody { 
+		type string {
+                    length "1..256" ;
+                }
+                description
+                    "Banner message input by user.";
+            }
+			
+            leaf headspace {
+	       type uint32 {
+                    range "0..256";
+                }
+                description
+                    "The number of space for the message head.";
+            }
+			
+            leaf tailspace {
+                type uint32 {
+                    range "0..256";
+                }
+                description
+                    "The number of space for the message tail.";
+           }
+        }
+    }
+	
+    grouping physical-device-grouping {
+        container physical-device {
+            description
+                "Including the physical device modules.";
+            container node {
+                uses OFNodeType;
+            }
+            list card {
+                key "resource-id";
+                uses of-config:OFResourceType ;
+                uses OFCardType;
+            }
+            
+            list fan {
+                key "resource-id";
+                uses of-config:OFResourceType ;
+                uses OFFanType;
+            }
+			
+            list power {
+                key "resource-id";
+                uses of-config:OFResourceType ;
+                uses OFPowerType;
+            }
+			
+            container banner {
+                uses OFBannerType;
+            }
+        }    
+        
+    }
+
+    grouping opt-module-grouping {
+        container opt-module {
+            description
+               "The specified attributes of optical module.";
+            leaf opt-connector-type {
+                type connector-type;
+                config false;
+                description
+                   "The connector value indicates the external optical 
+                    or electrical cable connector provided as the media interface";
+            }
+            leaf opt-single-double {
+                type fiber-type;
+                config false;
+                description
+                   "The type of fiber:single or double";
+            }
+            leaf opt-rx-wave-length {
+                type opt-wave-length-type;
+                config false;
+                description
+                   "The receive wavelength.";
+            }
+            leaf opt-tx-wave-length {
+                type opt-wave-length-type;
+                config false;
+                description
+                    "The transmit wavelength.";
+            }
+            leaf opt-bit-rate {
+                type uint32;
+                config false;
+                description
+                   "The nominal bit rate (BR, nominal) is specified in units of KBits/s.";
+            }
+            leaf opt-distance {
+                type uint32;
+                config false;
+                description
+                   "The optDistance is specified in units of Meter";
+            }
+            leaf opt-rx-power {
+                type int32;
+                config false;
+                description
+                    "The power is specified in units of dBm.";
+            }
+            leaf opt-tx-power {
+                type int32;
+                config false;
+                description
+                    "The power is specified in units of dBm.";
+            }
+            leaf opt-temperature {
+                type uint32;
+                config false;
+                description
+                    "unit:1 ℃";
+            }
+            leaf opt-bias-current {
+                type uint32;
+                config false;
+                description
+                    "The transmit bias current is specified in units of mA.";
+            }
+            leaf opt-voltage {
+                type uint32;
+                config false;
+                description
+                    "The optVoltage is specified in units of V.";
+            }
+            leaf opt-sfp-present {
+                type sfp-present-type;
+                config false;
+                description
+                    "The status of optical module present.The status includes present,notPresent or notSupport";
+            }
+            leaf opt-module-type {
+                type opt-module-type;
+                config false;
+                description
+                    "The type of optical module according to package type.";
+            }
+            leaf opt-media-type {
+                type opt-media-type;
+                config false;
+                description
+                    "The media type of optical module,singleMode or multiMode.";
+            }
+
+            leaf opt-laser-status {
+                type opt-laser-status-type;
+                config false;
+                description
+                    "The laser status of optical module.shutdown or open.";
+            }
+            leaf opt-ddm-support {
+                type opt-ddm-support-type;
+                config false;
+                description
+                    "The support condition of ddm.support or notSupport.";
+            }
+            leaf opt-vendor-name {
+                type string;
+                config false;
+                description
+                    "The vendor name shall be the full name of the corporation or
+                    a commonly accepted abbreviation of the name of the corporation.";
+            }
+            leaf opt-vendor-pn {
+                type string;
+                config false;
+                description
+                    "The vendor part number (vendor PN).";
+            }
+            leaf opt-vendor-sn {
+                type string;
+                config false;
+                description
+                    "The vendor serial number (vendor sn).";
+            }
+            leaf opt-vendor-reversion {
+                type string;
+                config false;
+                description
+                    "The vendor revision number (vendor rev).";
+            }
+            uses OFAlarmMaskType;
+
+            leaf opt-tx-power-high-thr{
+                type int32{
+                  range "-40..9";
+                }
+                description
+                    "The power threshold is specified in units of dBm.";
+            }
+            leaf opt-tx-power-low-thr{
+                type int32{
+                  range "-40..9";
+                }              
+                description
+                    "The power threshold is specified in units of dBm.";
+            }
+            leaf opt-rx-power-high-thr{
+                type int32{
+                  range "-40..9";
+                }
+                description
+                    "The power threshold is specified in units of dBm.";
+            }
+            leaf opt-rx-power-low-thr{
+                type int32{
+                  range "-40..9";
+                } 
+                description
+                    "The power threshold is specified in units of dBm.";
+            }            
+            leaf opt-temperature-high-thr {
+                type int32{
+                  range "-40..125";
+                } 
+                description
+                    "unit:1 ℃";
+            }    
+            leaf opt-bias-current-high-thr {
+                type uint32{
+                  range "0..131";
+                }
+                description
+                    "The transmit bias current threshold is specified in units of mA.";
+            } 
+          }                
+	   }
+
+    grouping OFAlarmMaskType {
+      leaf alarm-mask {
+        type boolean;
+        description "Alarm mask configuration by port position.true means open alarm mask";
+        default "false";
+      }
+    }
+
+    grouping port-attributes {
+      leaf port-type {
+        type port-type;
+        config false;
+        description
+        "The type of interface.optical or electrical.";
+      }
+      leaf alarm-inverse-mode {
+        type alarm-inverse-mode-type;
+        default "automatic";
+      }
+      uses OFAlarmMaskType;
+    }
+
+  augment "/of-config:capable-switch/of-config:logical-switches" {
+    uses manage-vlan-group;
+  }
+
+  augment "/of-config:capable-switch" {
+      uses physical-device-grouping;
+  }
+
+  augment "/of-config:capable-switch/of-config:resources/of-config:port" {
+      uses opt-module-grouping;
+  } 
+
+  augment "/of-config:capable-switch/of-config:resources/of-config:port" {
+      uses port-attributes;
+  } 
+}

--- a/yang-20191230/of-config-1.2-sptn-event.yang
+++ b/yang-20191230/of-config-1.2-sptn-event.yang
@@ -1,0 +1,63 @@
+module of-config-1.2-sptn-event {
+	namespace 'http://chinamobile.com.cn/sdn/sptn/sbi/schema/event';
+	prefix "sptn-event";
+
+	import of-config-1.2 { prefix of-config; }
+    import ietf-yang-types { prefix yang-types; } 
+	import of-config-1.2-sptn-alarm { prefix sptn-alm; }
+	
+	organization "SPTN Working Group";
+	contact "SPTN OpenFlow Extensions";
+	description "SPTN EVENT Yang Module";
+
+	revision "2019-06-06" {
+	description "initial";
+	reference "sptn openflow extensions draft";
+	}
+  
+    /*
+    * Groupings
+    */    
+    grouping event {
+		uses "of-config:OFResourceType" {
+			description "Resource-id of the resource raising the event - port, MEG, etc." ;
+		}  
+		
+		leaf SequenceNo {
+			type uint32 {
+			range "1..4294967295";
+			}
+		}
+		leaf eventcode {
+			type uint32 ;
+			description "event code" ;
+		}
+		leaf severity {
+			type "sptn-alm:severity-classification";
+			description "severity classification" ;
+		}
+		leaf timestamp {
+			type "yang-types:timestamp";
+			description "the timestamp is the number of seconds since 2000/01/01 00:00:00" ;
+		}
+		leaf description {
+			type string {
+			length "1..255" ;
+			}
+			description "the event description" ;
+		}
+		description "event";
+    }
+  
+    /*
+    * Notifications
+    */    
+    notification event-notification {
+        container event {
+            uses event;
+            description "event-notification";
+        }
+        description "event-notification";
+    }
+
+}

--- a/yang-20191230/of-config-1.2-sptn-lag.yang
+++ b/yang-20191230/of-config-1.2-sptn-lag.yang
@@ -1,0 +1,167 @@
+module of-config-1.2-sptn-lag {
+  namespace 'http://chinamobile.com.cn/sdn/sptn/sbi/schema/lag';
+  prefix "sptn-lag";
+
+  import of-config-1.2 { prefix of-config; }
+
+  organization "SPTN Working Group";
+  contact "SPTN OpenFlow Extensions";
+  description "SPTN LAG Yang Module";
+
+  revision "2019-11-18" {
+    description "initial";
+    reference "sptn openflow extensions draft";
+  }
+
+  
+  typedef lag-policy-type {
+    type enumeration {
+        enum "srcmac" {
+          value 1;
+        }
+        enum "dstmac" {
+          value 2;
+        } 
+        enum "srcdstmac" {
+          value 3;
+        }
+        enum "srcip" {
+          value 4;
+        } 
+        enum "dstip" {
+          value 5;
+        }
+        enum "srcdstip" {
+          value 6;
+        } 
+        enum "mpls-rtag7" {
+          value 7;
+        } 
+    }
+  }
+
+  typedef lag-mode-type {
+      type enumeration {
+        enum "sharing" {
+          value 1;
+        }
+        enum "non-sharing" {
+          value 2;
+        } 
+        enum "protect_1add1" {
+          value 3;
+        }
+      }
+  }
+
+  typedef lag-lacp-mode-type {
+      type enumeration {
+        enum "manual" {
+          value 1;
+        }
+        enum "static" {
+          value 2;
+        } 
+      }
+  }
+
+  typedef lag-reverse-type {
+      type enumeration {
+        enum "reverse" {
+          value 1;
+        }
+        enum "notReverse" {
+          value 2;
+        } 
+      }
+  }
+
+  typedef lag-status-type {
+    type enumeration {
+        enum "up" {
+          value 1;
+        }
+        enum "down" {
+          value 2;
+        } 
+      }
+  }
+
+  grouping OFLagType {
+	list lag {
+		key "resource-id";
+
+		description
+			"";
+		uses of-config:OFResourceType;
+	  
+		leaf lag-id {
+		  type uint32;
+		
+		  description
+			"The lag group id.";
+		}
+		
+		leaf openflow-port {
+		  type uint32;
+		  config false;
+		  description
+			"The lag openflow port.";
+		}	
+		
+		leaf description {
+		  type string;
+		
+		  description
+			"The description of lag.";
+		}
+
+		leaf lag-policy {
+		  type lag-policy-type;
+		
+		  description
+			"The lag policy.";
+		}
+		leaf lag-mode {
+		  type lag-mode-type ;
+		
+		  description
+			"The lag mode type.";
+		}
+		leaf lag-lacp-mode {
+		  type lag-lacp-mode-type;
+		
+		  description
+			"manual,static";
+		}
+		leaf lag-reverse-mode {
+		  type lag-reverse-type;
+		
+		  description
+			"reverse,unreverse";
+		}		
+		leaf-list port {
+			type leafref {
+			  path "/of-config:capable-switch/of-config:resources/of-config:port/of-config:resource-id";
+			}
+			description
+			"A resource identifier of a port of the OpenFlow Capable
+			Switch that the OpenFlow Logical Switch has exclusive access to.
+
+			Elements in this list MUST be unique. This means each
+			port element can only be referenced once.";
+		}
+		leaf lag-status {
+		  type lag-status-type;
+		
+		  description
+			"up,down";
+		}
+	}
+  }
+  
+  	augment "/of-config:capable-switch/of-config:resources" {
+      uses OFLagType;
+	}  
+
+}

--- a/yang-20191230/of-config-1.2-sptn-link-oam.yang
+++ b/yang-20191230/of-config-1.2-sptn-link-oam.yang
@@ -1,0 +1,467 @@
+module of-config-1.2-sptn-link-oam {
+  namespace 'http://chinamobile.com.cn/sdn/sptn/sbi/schema/link/oam'  ;
+  prefix "sptn-link-oam";
+
+  import of-config-1.2 { prefix of-config; }
+  import ietf-yang-types { prefix yang; }
+
+  organization "SPTN Working Group";
+  contact "SPTN OpenFlow Extensions";
+  description "SPTN Device Yang Module";
+
+  revision "2019-12-27" {
+    description "initial";
+    reference "sptn openflow extensions draft";
+  }
+
+  typedef enable-type {
+      type enumeration {
+        enum "enable" {
+          value 1;
+        }
+        enum "disable" {
+          value 2;
+        } 
+      }
+  }
+
+  typedef operate-status-type {
+      type enumeration {
+        enum "disabled" {
+          value 1;
+        }
+        enum "linkFault" {
+          value 2;
+        } 
+        enum "passiveWait" {
+          value 3;
+        }
+        enum "activeSendLocal" {
+          value 4;
+        }
+        enum "sendLocalAndRemote" {
+          value 5;
+        }
+        enum "sendLocalAndRemoteOk" {
+          value 6;
+        } 
+        enum "oamPeeringLocallyRejected" {
+          value 7;
+        }
+        enum "oamPeeringRemotelyRejected" {
+          value 8;
+        }
+        enum "operational" {
+          value 9;
+        }
+        enum "nonOperHalfDuplex" {
+          value 10;
+        }
+      }
+  }
+
+  typedef mode-type {
+      type enumeration {
+        enum "passive" {
+          value 1;
+        }
+        enum "active" {
+          value 2;
+        } 
+        enum "unknown"{
+          value 3;
+        }
+      }
+  }
+
+  typedef loopback-cmd-type {
+    type enumeration {
+        enum "initiatingLoopback" {
+          value 1;
+        } 
+        enum "terminatingLoopback" {
+          value 2;
+        } 
+      }
+  }
+  
+    typedef loopback-status-type {
+    type enumeration {
+        enum "noLoopback" {
+          value 1;
+        }
+        enum "remoteLoopback"{
+          value 2;
+        }
+        enum "localLoopback"{
+          value 3;
+        }
+        enum "unknown" {
+          value 4;
+        } 
+      }
+  }
+
+
+  typedef handing-type {
+    type enumeration {
+        enum "ignore" {
+          value 1;
+        }
+        enum "process" {
+          value 2;
+        } 
+       
+      }
+  }
+  grouping link-oam-grouping {
+    container link-oam {
+      description
+        "";
+      uses oam-local-grouping;
+      uses oam-peer-grouping;
+      uses oam-loopback-grouping;
+      uses oam-status-grouping;
+      uses oam-event-grouping;
+    }
+  }
+
+  grouping oam-local-grouping {
+    container local-entity {
+      description
+        "The attributes of oam entity.";
+      leaf admin-state {
+        type enable-type;
+      
+        description
+          "The oam protocal enable status.";
+      }
+      leaf work-mode {
+        type mode-type;
+      
+        description
+          "The mode of oam.passive,active";
+      }
+      container oam-entity-status {
+        description
+          "The status attributes";
+        leaf oper-status {
+          type operate-status-type;
+          config false;
+          description
+            "";
+        }
+        leaf pdu-size {
+          type uint32;
+          config false;
+          description
+            "The oam pdu size.";
+        }
+        leaf config-revision {
+          type uint32;
+          config false;
+          description
+            "";
+        }
+      }
+    }
+  }
+
+  grouping oam-peer-grouping {
+    container peer-entity {
+      description
+        "";
+        leaf peer-mac-address {
+          type yang:mac-address;
+          config false;
+          description
+            "The peer mac address.";
+        }
+        leaf peer-vendor-id {
+          type string;
+          config false;
+          description
+            "The vendor id of peer device.";
+        }
+        leaf peer-vendor-info {
+          type string;
+          config false;
+          description
+            "The vendor description of peer device";
+        }
+        leaf peer-working-mode {
+          type mode-type;
+          config false;
+          description
+            "The working mode of peer device.";
+        }
+        leaf pdu-size {
+          type uint32;
+          config false;
+          description
+            "The oam pdu size.";
+        }
+        leaf config-revision {
+          type uint32;
+          config false;
+          description
+            "";
+        }
+        
+    }
+  }
+
+  grouping oam-loopback-grouping {
+    container oam-loopback {
+      description
+        "The oam loopback information.";
+      leaf loopback-cmd {
+        type loopback-cmd-type;
+      
+        description
+          "The loopback  command.";
+      }
+      leaf loopback-status {
+        type loopback-status-type;
+		config false;
+        description
+          "The loopback status.";
+      }
+      leaf rx-handing {
+        type handing-type;
+      
+        description
+          "ignore,process";
+      }
+    }
+  }
+
+  grouping oam-status-grouping {
+    container oam-status {
+      description
+        "The oam loopback information.";
+      leaf frames-tx {
+        type uint32;
+        config false;
+        description
+          "The transmite frame count.";
+      }
+      leaf frames-rx {
+        type uint32;
+        config false;
+        description
+          "The receive frame count.";
+      }
+
+      leaf event-notification-frames-rx {
+        type uint32;
+        config false;
+        description
+          "The receive event notification  frame count."; 
+      }
+
+      leaf event-notification-frames-tx {
+        type uint32;
+        config false;
+        description
+          "The transmite event notification  frame count."; 
+      }
+      leaf dul-event-notification-frames-tx {
+        type uint32;
+        config false;
+        description
+          "The transmite duplicate event notification  frame count."; 
+      }
+      leaf dul-event-notification-frames-rx {
+        type uint32;
+        config false;
+        description
+          "The receive duplicate event notification  frame count."; 
+      }
+
+      leaf loopback-control-rx {
+        type uint32;
+        config false;
+        description
+          ""; 
+      }
+
+      leaf loopback-control-tx {
+        type uint32;
+        config false;
+        description
+          ""; 
+      }
+
+      leaf variable-request-rx {
+        type uint32;
+        config false;
+        description
+          ""; 
+      }
+
+      leaf variable-request-tx {
+        type uint32;
+        config false;
+        description
+          ""; 
+      }
+
+      leaf variable-response-rx {
+        type uint32;
+        config false;
+        description
+          ""; 
+      }
+
+      leaf variable-response-tx {
+        type uint32;
+        config false;
+        description
+          ""; 
+      }
+
+      leaf org-specific-tx {
+        type uint32;
+        config false;
+        description
+          ""; 
+      }
+
+      leaf org-specific-rx {
+        type uint32;
+        config false;
+        description
+          ""; 
+      }
+
+      leaf unsupported-codes-tx {
+        type uint32;
+        config false;
+        description
+          ""; 
+      }
+
+      leaf unsupported-codes-rx {
+        type uint32;
+        config false;
+        description
+          ""; 
+      }
+      leaf lost-frames-rx {
+        type uint32;
+        config false;
+        description
+          ""; 
+      }
+    }
+  }
+
+  grouping oam-event-grouping {
+    container oam-event {
+      description
+        "The oam event config.";
+      leaf err-period-window-hi {
+        type uint32;
+      
+        description
+          "";
+      }
+      leaf err-period-window-lo {
+        type uint32;
+      
+        description
+          "";
+      }
+      leaf err-period-threshold-hi {
+        type uint32;
+      
+        description
+          "";
+      }
+      leaf err-period-threshold-lo {
+        type uint32;
+      
+        description
+          "";
+      }
+      leaf err-sys-period-event-enable {
+        type enable-type;
+      
+        description
+          "";
+      }
+      leaf err-sys-frame-period-window {
+        type uint32;
+      
+        description
+          "";
+      }
+      leaf err-sys-frame-period-threshold {
+        type uint32;
+      
+        description
+          "";
+      }
+      leaf err-frame-period-event-enable {
+        type enable-type;
+      
+        description
+          "";
+      }
+      leaf err-frame-window{
+        type uint32;
+      
+        description
+          "";
+      }
+      leaf err-frame-threshold{
+        type uint32;
+      
+        description
+          "";
+      }
+      leaf err-frame-event-enable {
+        type enable-type;
+      
+        description
+          "";
+      }
+      leaf err-frame-secs-summary-window{
+        type uint32;
+      
+        description
+          "";
+      }
+      leaf err-frame-secs-summary-threshold{
+        type uint32;
+      
+        description
+          "";
+      }
+      leaf err-frame-secs-summary-enable {
+        type enable-type;
+      
+        description
+          "";
+      }
+      leaf dying-gasp-enable{
+        type enable-type;
+      
+        description
+          "";
+      }
+      leaf critical-event-enable{
+        type enable-type;
+      
+        description
+          "";
+      }
+    }
+  }
+
+  augment "/of-config:capable-switch/of-config:resources/of-config:port" {
+      uses link-oam-grouping;
+  }
+ 
+}

--- a/yang-20191230/of-config-1.2-sptn-oam.yang
+++ b/yang-20191230/of-config-1.2-sptn-oam.yang
@@ -1,0 +1,1638 @@
+module of-config-1.2-sptn-oam {
+     namespace 'http://chinamobile.com.cn/sdn/sptn/sbi/schema/oam' ;
+     prefix "sptn-oam";
+
+     import of-config-1.2 { prefix of-config; }
+     import ietf-yang-types { prefix yang; }
+
+     organization "SPTN Working Group";
+     contact "SPTN OpenFlow Extensions";
+     description "SPTN OAM Yang Module";
+
+     revision "2016-01-16" {
+       description "initial";
+       reference "sptn openflow extensions draft";
+     }
+
+     typedef direction {
+       type enumeration {
+         enum "up" {
+           value 1;
+           description "The direction to the partner is through the switch";
+         }
+         enum "down" {
+           value 2;
+           description "The direction to the partner is at egress";
+         }
+       }
+     }
+
+     typedef pm-role {
+       type enumeration {
+         enum "initiator" {
+           value 0;
+           description "Initiator.";
+         }
+         enum "responder" {
+           value 1;
+           description "Responder.";
+         }
+         enum "both" {
+           value 2;
+           description "both.";
+         }
+       }
+     }
+
+     typedef mip-creation {
+       type enumeration {
+         enum "none" {
+           value 1;
+           description "No MIPs can be created for this MEG";
+         }
+         enum "automatic" {
+           value 2;
+           description "MIPs are automatically created if there is a MEP at the next lower active MD-level.";
+         }
+         enum "manual" {
+           value 3;
+           description "MIPs can be manually created only if there is a MEP at the next lower active MD-level.";
+         }
+       }
+       description "An enumerated value indicating whether the management entity can
+       create MHFs (MIP Half Function) for this MEG.";
+     }
+
+     typedef mip-type {
+       type enumeration {
+         enum "node" {
+           value 1;
+         }
+         enum "interface" {
+           value 2;
+         }
+       }
+     }
+
+     typedef tool-types{
+       type enumeration {
+         enum "CCM" {
+           value 0;
+         }
+         enum "LM" {
+           value 1;
+         }
+         enum "SLM" {
+           value 2;
+         }
+       }
+     }
+
+     typedef rmep-id {
+       type string ;
+       description "48-bit MEP Id";
+     }
+
+     typedef openflow-mp-id {
+       type uint32 ;
+       description "OpenFlow pipeline field that connects the OpenFlow dataplane with a configured Maintenance Point.";
+     }
+
+     typedef admin-state {
+       type enumeration {
+         enum "lock" {
+           value 1;
+         }
+         enum "normal" {
+           value 2;
+         }
+       }
+     }
+
+     typedef ccm-period {
+       type enumeration {
+         enum "Invalid" {
+           value 0;
+         }
+         enum "3.33MS" {
+           value 1;
+           description "Default for protection";
+         }
+         enum "10MS" {
+           value 2;
+         }
+         enum "100MS" {
+           value 3;
+         }
+         enum "1S" {
+           value 4;
+         }
+         enum "10S" {
+           value 5;
+         }
+         enum "1MIN" {
+           value 6;
+         }
+         enum "10MIN" {
+           value 7;
+         }
+       }
+       description "Values for CC packet transmit interval.";
+     }
+
+     typedef dm-period {
+       type enumeration {
+         enum "0" {
+           value 0;
+         }
+         enum "10 MS" {
+           value 1;
+         }
+         enum "100 MS" {
+           value 2;
+         }
+         enum "1 SEC" {
+           value 3;
+         }
+         enum "1 MIN" {
+           value 4;
+         }
+         enum "10 MIN" {
+           value 5;
+         }
+       }
+       description "Message period values for delay measurements.";
+     }
+
+     typedef message-period {
+       type enumeration {
+         enum "0" {
+           value 0;
+         }
+         enum "1 SEC" {
+           value 1;
+         }
+         enum "1 MIN" {
+           value 2;
+         }
+       }
+       description "Message period values for AIS, LCK, and CSF PDUs.";
+     }
+
+     typedef loopback-period {
+       type enumeration {
+         enum "0" {
+           value 0;
+         }
+         enum "1 SEC" {
+           value 1;
+         }
+         enum "10 SEC" {
+           value 2;
+         }
+         enum "1 MIN" {
+           value 3;
+         }
+         enum "10 MIN" {
+           value 4;
+         }
+       }
+       description "Loopback message period values.";
+     }
+
+
+     typedef priority {
+       type enumeration {
+         enum "BE" {
+           value 0;
+         }
+         enum "AF1" {
+           value 1;
+         }
+         enum "AF2" {
+           value 2;
+         }
+         enum "AF3" {
+           value 3;
+         }
+         enum "AF4" {
+           value 4;
+         }
+         enum "EF" {
+           value 5;
+         }
+         enum "CS6" {
+           value 6;
+         }
+         enum "CS7" {
+           value 7;
+         }
+       }
+       description "PHB values for priority.";
+     }
+
+     typedef destination-mp-type {
+       type enumeration {
+         enum "MEP" {
+           value 0;
+           description "ICC-based MEP Id.";
+         }
+         enum "MIP" {
+           value 1;
+           description "ICC-based MIP Id.";
+         }
+       }
+     }
+
+     typedef protection-scheme {
+       type enumeration {
+         enum "bi-directional" {
+           value 0;
+         }
+         enum "uni-directional" {
+           value 1;
+         }
+       }
+     }
+
+     typedef protection-architecture {
+       type enumeration {
+         enum "1-to-1" {
+           value 0;
+         }
+         enum "1-plus-1" {
+           value 1;
+         }
+         enum "1-to-N" {
+           value 2;
+         }
+       }
+     }
+
+     typedef lm-dm-state {
+       type enumeration {
+         enum "stopped" {
+           value 0;
+         }
+         enum "running" {
+           value 1;
+         }
+       }
+     }
+
+     typedef test-tlv-type {
+       type enumeration {
+         enum "Null signal - all zero without CRC-32" {
+           value 0;
+         }
+         enum "Null signal - all zero with CRC-32" {
+           value 1;
+         }
+         enum "PRBS 2power31-1 without CRC-32" {
+           value 2;
+         }
+         enum "PRBS 2power31-1 with CRC-32" {
+           value 3;
+         }
+       }
+     }
+
+     typedef meg-level {
+       type uint16 {
+         range "0..7";
+       }
+     }
+
+     typedef ps-requests {
+       type enumeration {
+         enum "Clear" {
+           value 0;
+         }
+         enum "Lockout of protection" {
+           value 1;
+         }
+         enum "Lockout of work" {
+           value 12;
+         }
+         enum "Signal fail for protection" {
+           value 2;
+         }
+         enum "forced switch" {
+           value 3;
+         }
+         enum "Signal fail for work" {
+           value 4;
+         }
+         enum "Signal degrade" {
+           value 5;
+         }
+         enum "Manual switch" {
+           value 6;
+         }
+         enum "Wait-to-restore" {
+           value 7;
+         }
+         enum "Exercise" {
+           value 8;
+         }
+         enum "Reverse request" {
+           value 9;
+         }
+         enum "Do not revert" {
+           value 10;
+         }
+         enum "No request" {
+           value 11;
+         }
+       }
+     }
+
+     typedef ps-status {
+       type enumeration {
+         enum "switch_to_work" {
+           value 1;
+         }
+         enum "switch_to_protection" {
+           value 2;
+         }
+         enum "protection_group_deleted" {
+           value 3;
+         }
+       }
+     }
+
+     typedef lb-discovery {
+       type enumeration {
+         enum "none" {
+           value 0;
+           description "The current loopback is not for discovery";
+         }
+         enum "ingress" {
+           value 1;
+           description "The current loopback is for discovery";
+         }
+         enum "egress" {
+           value 2;
+           description "The current loopback is for discovery";
+
+         }
+       }
+     }
+
+    grouping mlp-config {
+      description "MLP Config class" ;
+      leaf role {
+        type enumeration {
+          enum "protection" {
+            value 0;
+          }
+          enum "working" {
+            value 1;
+          }
+        }
+      }
+      leaf direction {
+        type enumeration {
+          enum "rx" {
+            value 1;
+            description "The direction is from the partner";
+          }
+          enum "tx" {
+            value 2;
+            description "The direction is to the partner";
+          }
+        }
+        description "direction";
+      }
+    }
+
+    grouping ccm-grouping {
+       description "Common CCM attributes.";
+       leaf period {
+         type ccm-period;
+         default "3.33MS";
+         description "The transmit interval for CCM frames.";
+       }
+       leaf enable {
+         type boolean;
+         default "true";
+         description "The object indicates whether CCM frames can be sent by the MEG";
+       }
+       leaf nbrOfSentCCM {
+         type yang:counter32;
+         config false;
+       }
+       leaf nbrOfRcvCCM {
+         type yang:counter32;
+         config false;
+       }
+    }
+
+    grouping lb-grouping {
+      leaf discovery {
+        type lb-discovery;
+        default "none";
+      }
+      leaf testTlvPresent {
+        type boolean;
+        default "false";
+      }
+      leaf testTlvType {
+        type test-tlv-type ;
+        default "Null signal - all zero without CRC-32";
+      }
+      leaf destination {
+        type rmep-id;
+        mandatory true;
+      }
+      leaf destinationType {
+        type destination-mp-type;
+        mandatory true;
+      }
+      leaf period {
+        type loopback-period;
+        description "This object indicates the interval for sending LBM packets.";
+      }
+      leaf nbrOfPkt {
+        type uint32;
+        default 1;
+      }
+      leaf pktLength {
+        type uint32;
+        default 64;
+      }
+      leaf enable {
+        type boolean;
+        default false;
+      }
+      leaf resultOK {
+        type boolean;
+        config false;
+      }
+      leaf nbrOfLbrIn {
+        type yang:counter32;
+        config false;
+      }
+      leaf nbrOfLbrInOutOfOrder {
+        type yang:counter32;
+        config false;
+      }
+      leaf nbrOfLbrBadMsdu {
+        type yang:counter32;
+        config false;
+      }
+    }
+
+    grouping lck-csf-ais-grouping {
+      leaf period {
+        type message-period;
+        default "1 SEC";
+      }
+      leaf enable {
+        type boolean;
+        default "false";
+      }
+    }
+
+    grouping tst-grouping {
+      leaf role {
+        type enumeration {
+          enum "initiator" {
+            value 0;
+            description "Initiator.";
+          }
+          enum "responder" {
+            value 1;
+            description "Responder.";
+          }
+        }
+        mandatory true;
+      }
+      leaf type {
+        type enumeration {
+          enum "in-service" {
+            value 0;
+          }
+          enum "out-of-service" {
+            value 1;
+          }
+        }
+        mandatory true;
+      }
+      leaf destination {
+        type rmep-id;
+        mandatory true;
+      }
+      leaf interval { 
+        type uint32 {
+          range "0..60000000";
+        }
+        default "1000000";
+        description "Test interval in microseconds.";
+      }
+      leaf duration {
+        type uint16 {
+          range "0..3600";
+        }
+        default "60";
+        description "Test duration in seconds.";
+      }
+      leaf pktLength {
+        type uint32 {
+          range "64..9600";
+         }
+         default 64;
+      }
+      leaf enable {
+        type boolean;
+        default "false";
+      }
+      leaf testTlvType {
+        type test-tlv-type;
+        default "Null signal - all zero without CRC-32";
+      }
+      leaf nbrOfTestOut {
+        type yang:counter32;
+        config false;
+      }
+      leaf nbrOfTestIn {
+        type yang:counter32;
+        config false;
+      }
+      leaf nbrOfTstInOutOfOrder {
+        type yang:counter32;
+        config false;
+      }
+      leaf nbrOfTstInCrcError {
+        type yang:counter32;
+        config false;
+      }
+      leaf nbrOfTstInBerError {
+        type yang:counter32;
+        config false;
+      }
+    }
+
+    grouping lm-dm-grouping {
+     leaf destinationType {
+        type destination-mp-type ;
+        mandatory true;
+      }
+      leaf destination {
+        description "2 bytes for ICC-based MEP Id, 14 bytes for ICC-based MIP Id.";
+        type string;
+        mandatory true;
+      }
+      leaf enable {
+        type boolean;
+        default "false";
+      }
+    }
+
+    grouping proactive-lm-grouping {
+      uses "lm-dm-grouping";
+      leaf toolTypes {
+        type tool-types;
+        default "CCM";
+      }
+      leaf period {
+        type ccm-period;
+        default "3.33MS";
+      }
+      list pro-lm-pm-15min-24hr {
+        config false;
+        description "Read only values.";
+        leaf xN_FLR {
+          description "Maximum Near-end Frame Loss Ratio, in milli-percent.";
+          type uint32;
+        }
+        leaf aN_FLR {
+          description "Average Near-end Frame Loss Ratio, in milli-percent.";
+          type uint32;
+        }
+        leaf mN_FLR {
+          description "Minimum Near-end Frame Loss Ratio, in milli-percent.";
+          type uint32;
+        }
+        leaf xF_FLR {
+          description "Maximum Far-end Frame Loss Ratio, in milli-percent.";
+          type uint32;
+        }
+        leaf aF_FLR {
+          description "Average Far-end Frame Loss Ratio, in milli-percent.";
+          type uint32;
+        }
+        leaf mF_FLR {
+          description "Minimum Far-end Frame Loss Ratio, in milli-percent.";
+          type uint32;
+        }
+      }
+    }
+
+    grouping on-demand-lm-grouping {
+      uses "lm-dm-grouping";
+      leaf toolTypes {
+        type enumeration {
+          enum "LM" {
+            value 1;
+          }
+          enum "SLM" {
+            value 2;
+          }
+        }
+        default "LM";
+      }
+      leaf period {
+        type ccm-period;
+        default "3.33MS";
+      }
+      leaf role {
+        type pm-role;
+        default "both";
+      }
+      leaf state {
+        type lm-dm-state;
+        config false;
+      }
+      list od-lm-pm-snapshot {
+        config false;
+        description "Read only values.";
+        leaf tN_TFCnt {
+          description "Total Near-end transmitted frames since the single-ended LM initiated.";
+          type yang:counter32;
+        }
+        leaf tN_LFCnt {
+          description "Total Near-end lost frames since the single-ended LM initiated.";
+          type uint32;
+        }
+        leaf tF_TFCnt {
+          description "Total Far-end transmitted frames since the single-ended LM initiated.";
+          type yang:counter32;
+        }
+        leaf tF_LFCnt {
+          description "Total Far-end lost frames since the single-ended LM initiated.";
+          type uint32;
+        }
+        leaf tN_FLR {
+          description "Total Near-end Frame Loss Ratio since the single-ended LM initiated, in milli-percent.";
+          type uint32;
+        }
+        leaf tF_FLR {
+          description "Total Far-end Frame Loss Ratio since the single-ended LM initiated, in milli-percent.";
+          type uint32;
+        }
+        leaf sLMCnt {
+          description "Number of successful loss measurements.";
+          type yang:counter32;
+        }
+        leaf yLMCnt {
+          description "Number of unsuccessful loss measurements.";
+          type yang:counter32;
+        }
+      }
+    }
+
+    grouping proactive-dm-grouping {
+      uses "lm-dm-grouping";
+      leaf period {
+        type dm-period;
+        default "1 SEC";
+      }
+      leaf frameLen {
+        type uint32;
+        default 64;
+      }
+      list pro-dm-pm-15min-24hr {
+        config false;
+        description "Read only values.";
+        leaf xB_FD {
+          description "Maximum Bi-directional Frame Delay, in microseconds.";
+          type uint32;
+        }
+        leaf aB_FD {
+          description "Average Bi-directional Frame Delay, in microseconds.";
+          type uint32;
+        }
+        leaf mB_FD {
+          description "Minimum Bi-directional Frame Delay, in microseconds.";
+          type uint32;
+        }
+        leaf xN_FDV {
+          description "Maximum Near-end Frame Delay Variation, in microseconds.";
+          type uint32;
+        }
+        leaf aN_FDV {
+          description "Average Near-end Frame Delay Variation, in microseconds.";
+          type uint32;
+        }
+        leaf mN_FDV {
+          description "Minimum Near-end Frame Delay Variation, in microseconds.";
+          type uint32;
+        }
+        leaf xF_FDV {
+          description "Maximum Far-end Frame Delay Variation, in microseconds.";
+          type uint32;
+        }
+        leaf aF_FDV {
+          description "Average Far-end Frame Delay Variation, in microseconds.";
+          type uint32;
+        }
+        leaf mF_FDV {
+          description "Minimum Far-end Frame Delay Variation, in microseconds.";
+          type uint32;
+         }
+       }
+    }
+
+    grouping on-demand-dm-grouping {
+      uses "lm-dm-grouping";
+      leaf period {
+        type dm-period;
+        default "1 SEC";
+      }
+      leaf frameLen {
+        type uint32;
+        default 64;
+      }
+      list od-dm-pm-snapshot {
+        config false;
+        description "Read only values.";
+        leaf tN_FD {
+          description "i-th on-demand frame delay measurement result in near-end direction, in microseconds.";
+          type uint32;
+        }
+        leaf tF_FD {
+          description "i-th on-demand frame delay measurement result in near-end direction, in microseconds.";
+          type uint32;
+        }
+        leaf tB_FD {
+          description "i-th on-demand frame delay measurement result in near-end direction, in microseconds.";
+          type uint32;
+        }
+        leaf elapsedTime {
+          description "Elapsed time since beginning of delay measurement, in 10 ms.";
+          type yang:timeticks;
+        }
+        leaf sFDMCnt {
+          description "Number of successful delay measurements until now.";
+          type yang:counter32;
+        }
+        leaf uFDMCnt {
+          description "Number of unsuccessful delay measurements until now.";
+          type yang:counter32;
+        }
+      }
+    }
+
+    grouping protection-status {
+       leaf lastApsTx {
+         type string;
+         description "Last APS PDU transmitted.";
+       }
+       leaf lastApsRx {
+         type string;
+         description "Last APS PDU received.";
+       }
+       leaf lastPsRequestExecuted {
+         type ps-requests ;
+       }
+       leaf currentPsStatus {
+         type ps-status ;
+       }
+       leaf switchOverCount {
+         type yang:counter32;
+         description "Number of switchovers since the system starts";
+       }
+       leaf lastSwitchOverTime {
+         type yang:timestamp;
+         description "Time tick since last switch protection is executed";
+       }
+    }
+
+augment "/of-config:capable-switch/of-config:resources" {
+
+       list Ethernet_MEG {
+         key "resource-id";
+
+         uses "of-config:OFResourceType" ;
+
+         leaf index {
+           type uint32;
+           description "Local Id for MEG.";
+         }
+
+         leaf nameFormat {
+           type uint16;
+           description "ICC name format, only permissible value is 0.";
+           default 0;
+         }
+
+         leaf name {
+           type string {
+             length "1..48";
+           }
+           mandatory true;
+           description "48 byte MEG Id, including format and length bytes";
+         }
+
+         leaf level {
+           type meg-level;
+           default 4;
+         }
+
+         leaf managedInstanceType {
+           description "managedInstance type";
+           type enumeration {
+             enum "Ethernet" {
+               value 0;
+               description "Type is MPLS-TP Section (between MPLS LSRs).";
+             }
+             enum "VPWS" {
+               value 1;
+               description "Type is an end-to-end LSP (between MPLS LERs).";
+             }
+           }
+           default "VPWS";
+         }
+
+         leaf primaryVid {
+           type uint16;
+         }
+
+         leaf mipCreation {
+           type mip-creation;
+           default "automatic";
+         }
+
+         choice mep-or-mip {
+
+         case mep {
+
+         container Local_MEP {
+           description "Ethernet Local MEP";
+           leaf openFlowMpId {
+             type openflow-mp-id;
+             mandatory "true";
+           }
+           leaf mepId {
+             type uint16 {
+               range "0..8191";
+             }
+             mandatory true;
+             description "Local MEP identity.";
+           }
+           leaf interfaceType {
+             type enumeration {
+               enum "physical port" {
+                 value 0;
+               }
+               enum "LAG group" {
+                 value 1;
+               }
+             }
+             default "physical port";
+           }
+           leaf ifNum {
+             type uint32;
+             description "Interface number.";
+             mandatory true;
+           }
+           leaf macAddress {
+             type yang:mac-address;
+             mandatory true;
+           }
+           leaf direction {
+             type direction ;
+             default "up";
+           }
+           leaf enable {
+             type boolean;
+             default "false";
+           }
+
+           container CCM {
+             description "CCM";
+             uses "ccm-grouping";
+
+             leaf priority {
+               type priority;
+               default "CS7";
+             }
+
+             list MEP_CCM_Database {
+               config false;
+               leaf rMepId {
+                 type uint16 {
+                   range "0..8191";
+                 }
+               }
+               leaf rMepState {
+                 type enumeration {
+                   enum "idle" {
+                     value 1;
+                   }
+                   enum "Start" {
+                     value 2;
+                     description "The timer has not expired since the state machine was reset and no valid CCM has yet been received.";
+                   }
+                   enum "Failed" {
+                     value 3;
+                     description "The timer has expired both since the state machine was reset and since a valid CCM was received.";
+                   }
+                   enum "Ok" {
+                     value 4;
+                     description "The timer has not expired since a valid CCM was received.";
+                   }
+                 }
+               }
+               leaf macAddress {
+                 type yang:mac-address;
+               }
+               leaf lastUpdateTime {
+                 type yang:timestamp;
+               }
+             }
+           }
+
+           list LB {
+             key "instance";
+             description "Loopback configuration.";
+             leaf instance {
+               type uint32;
+               description "Loopback instance.";
+               mandatory true;
+             }
+             uses "lb-grouping" ;
+
+             leaf priority {
+               type priority;
+               default "CS7";
+             }
+
+             leaf dropEligibility {
+               type boolean;
+               default "false";
+             }
+
+             leaf macAddress {
+               type yang:mac-address ;
+             }
+
+           }
+
+           list TST {
+             key "instance";
+             leaf instance {
+               type uint32;
+               description "Test instance.";
+               mandatory true;
+             }
+             uses "tst-grouping";
+
+             leaf priority {
+               type priority;
+               default "CS7";
+             }
+
+             leaf dropEligibility {
+               type boolean;
+               default "false";
+             }
+           }
+
+           container AIS {
+             description "Alarm indication suppression message configuration.";
+             uses "lck-csf-ais-grouping";
+
+             leaf priority {
+               type priority;
+               default "CS7";
+             }
+
+             leaf clientMegLevel {
+               type meg-level;
+               mandatory true;
+             }
+           }
+
+           container LCK {
+             description "Lock report message configuration.";
+             uses "lck-csf-ais-grouping";
+
+             leaf priority {
+               type priority;
+               default "CS7";
+             }
+
+             leaf clientMegLevel {
+               type meg-level;
+               mandatory true;
+             }
+           }
+
+           container CSF {
+             description "Client signal fail message configuration.";
+             uses "lck-csf-ais-grouping";
+
+             leaf priority {
+               type priority;
+               default "CS7";
+             }
+
+           }
+
+           container LT {
+             description "Link trace message configuration.";
+             leaf destination {
+               type yang:mac-address;
+               mandatory true;
+             }
+             leaf priority {
+               type priority;
+               default "CS7";
+             }
+             leaf ttl {
+               type uint8;
+               default 10;
+             }
+             leaf enable {
+               type boolean;
+               default false;
+             }
+             leaf resultOk {
+               type boolean;
+               config false;
+             }
+             leaf nbrOfUnexpectedLtrIn {
+               type uint32;
+               config false;
+             }
+             list LT_Reply {
+               description "Link trace reply database (Read-Only).";
+               config false;
+               leaf sequenceNumber {
+                 type uint32;
+               }
+               leaf receiveOrder{
+                 type uint32;
+               }
+               leaf isForwarded {
+                 type boolean;
+               }
+               leaf terminalMep {
+                 type boolean;
+               }
+               leaf lastTransactionId {
+                 type uint64;
+               }
+               leaf nextTransactionId {
+                 type uint64;
+               }
+               leaf ltrRelayAction {
+                 type uint32;
+               }
+               leaf ltrIngressAction {
+                 type uint32;
+               }
+               leaf ltrIngressAddress {
+                 type yang:mac-address;
+               }
+               leaf ltrIngressPortIdSubtype {
+                 type uint32;
+               }
+               leaf ltrIngressPortId {
+                 type uint32;
+               }
+               leaf ltrEngressAction {
+                 type uint32;
+               }
+               leaf ltrEngressAddress {
+                 type yang:mac-address;
+               }
+               leaf ltrEngressPortIdSubtype {
+                 type uint32;
+               }
+               leaf ltrEngressPortId {
+                 type uint32;
+               }
+               leaf ltrOrgSpecificTlv {
+                 type string {
+                   length "1..1500";
+                 }
+               }
+               leaf ltrSenderIdTlv {
+                 type string {
+                   length "1..1500";
+                 }
+               }
+             }
+           }
+
+           container Proactive_LM {
+             description "Proactive Loss Management configuration.";
+
+             leaf priority {
+               type priority;
+               default "CS7";
+             }
+
+             uses "proactive-lm-grouping";
+           }
+
+           container OnDemand_LM {
+             description "On Demand Loss Management configuration.";
+
+             leaf priority {
+               type priority;
+               default "CS7";
+             }
+             uses "on-demand-lm-grouping";
+
+           }
+
+           container Proactive_DM {
+             description "Proactive Delay Management configuration.";
+
+             leaf priority {
+               type priority;
+               default "CS7";
+             }
+
+             uses "proactive-dm-grouping";
+           } 
+
+           container ONDemand_DM {
+             description "On Demand Delay Measurement configuration.";
+
+             leaf priority {
+               type priority;
+               default "CS7";
+             }
+
+             uses "on-demand-dm-grouping";
+           }
+         }
+
+         list Remote_MEP {
+           key "openFlowMpId";
+           leaf openFlowMpId {
+             type openflow-mp-id;
+             mandatory true;
+             description "Pipeline metadata associating PDU with remote MEP.";
+           }
+           leaf rMepId {
+             mandatory true;
+             type rmep-id ;
+           }
+           leaf mepId {
+             mandatory true;
+             type uint16 ;
+           }
+         }
+
+         list Remote_MIP {
+           key "openFlowMpId";
+           leaf openFlowMpId {
+             type openflow-mp-id ;
+             mandatory true;
+             description "Pipeline metadata associating PDU with remote MIP.";
+           }
+           leaf macAddress {
+             type yang:mac-address ;
+             mandatory true;
+           }
+         }
+
+        } // case mep
+
+        case mip {
+
+         list Local_MIP {
+           key "openFlowMpId";
+           leaf openFlowMpId {
+             type openflow-mp-id;
+             mandatory true;
+             description "Pipeline metadata associating PDU with local MIP.";
+           }
+           leaf macAddress {
+             type yang:mac-address ;
+             mandatory true;
+           }
+         }
+
+        } // case mip
+
+       } //mep-or-mip
+       } // meg
+
+
+       list G.8113.1_MEG {
+         key "resource-id";
+
+         uses "of-config:OFResourceType" ;
+
+         leaf index {
+           type uint32;
+           description "The object indicates the index of the MEG";
+         }
+         leaf nameFormat {
+           type uint16;
+           description "ICC name format, only permissible value is 0.";
+           default 0;
+         }
+         leaf name {
+           type string {
+             length "1..14";
+           }
+           mandatory true;
+           description "The object indicates the name of the MEG";
+         }
+         leaf managedInstanceType {
+           type enumeration {
+             enum "section" {
+               value 0;
+               description "Type is MPLS-TP Section (between MPLS LSRs).";
+             }
+             enum "lsp" {
+               value 1;
+               description "Type is an end-to-end LSP (between MPLS LERs).";
+             }
+             enum "pw" {
+               value 2;
+               description "Type is an end-to-end Single-Segment
+               Pseudowire (SS-PW) or MS-PW (between T-PEs).";
+             }       
+           }
+           mandatory true;
+           description "The object indicates the layer of the MEG";
+         }
+         leaf mipCreation {
+           type mip-creation;
+           default "automatic";
+         }
+
+         choice mep-or-mip {
+
+         case mep {
+
+         container Local_MEP {
+           description "G.8113.1 Local MEP";
+           leaf openFlowMpId {
+             type openflow-mp-id ;
+             mandatory true;
+           }
+           leaf serveropenFlowMpId {
+             description "Identifies the server layer MEP for LCK and AIS for PW or LSP.";
+             type openflow-mp-id ;
+             mandatory true;
+           } 
+           leaf mepId {
+             type uint16 {
+               range "0..8191" ;
+             }
+             mandatory true;
+             description "Local MEP identity.";
+           }
+           leaf direction {
+             type direction ;
+             default "down";
+             description "Only down MEPs supported.";
+           }
+           leaf enable {
+             type boolean;
+             default false;
+           }
+
+           container CCM {
+             description "CCM configuration.";
+             uses "ccm-grouping";
+
+             leaf phb {
+               type priority;
+               default "CS7";
+             }
+
+           }
+
+           list LB {
+             key "instance";
+             description "Loopback configuration.";
+             leaf instance {
+               type uint32;
+               description "Loopback instance.";
+               mandatory true;
+             }
+             uses "lb-grouping";
+
+             leaf phb {
+               type priority;
+               default "CS7";
+             }
+
+             leaf ttl {
+               type uint8;
+               default 10;
+             }
+
+             leaf mipICC {
+               type string {
+                 length "0..6";
+               }
+               mandatory true;
+             }
+           }
+
+           list TST {
+             key "instance";
+             leaf instance {
+               type uint32;
+               mandatory true;
+               description "Test instance.";
+             }
+             uses "tst-grouping";
+
+             leaf phb {
+               type priority;
+               default "CS7";
+             }
+
+           }
+
+           container AIS {
+             description "Alarm indication suppression message configuration.";
+             uses "lck-csf-ais-grouping";
+
+             leaf phb {
+               type priority;
+               default "CS7";
+             }
+
+           }
+
+           container LCK {
+             description "Lock report message configuration.";
+             uses "lck-csf-ais-grouping";
+
+             leaf phb {
+               type priority;
+               default "CS7";
+             }
+
+           }
+
+           container CSF {
+             description "Client signal fail message configuration.";
+             uses "lck-csf-ais-grouping";
+
+             leaf phb {
+               type priority;
+               default "CS7";
+             }
+
+           }
+
+           container Proactive_LM {
+             description "Proactive Loss Management configuration.";
+
+             leaf phb {
+               type priority;
+               default "CS7";
+             }
+             uses "proactive-lm-grouping";
+
+           }
+
+           container OnDemand_LM {
+             description "On Demand Loss Management configuration.";
+
+             leaf phb {
+               type priority;
+               default "CS7";
+             }
+
+             uses "on-demand-lm-grouping";
+           }
+
+           container Proactive_DM {
+             description "Proactive Delay Management configuration.";
+
+             leaf phb {
+               type priority;
+               default "CS7";
+             }
+
+             uses "proactive-dm-grouping";
+           } 
+
+           container OnDemand_DM {
+             description "On Demand Delay Measurement configuration.";
+
+             leaf phb {
+               type priority;
+               default "CS7";
+             }
+
+             uses "on-demand-dm-grouping";
+           }
+         }
+
+         list Remote_MEP {
+           key "openFlowMpId";
+           leaf openFlowMpId {
+             type openflow-mp-id;
+             mandatory true;
+           }
+           leaf mepId {
+             type uint16 ;
+             mandatory true;
+           }
+           leaf rMepId {
+             mandatory true;
+             type rmep-id ;
+           }
+         }
+
+         list Remote_MIP {
+           key "openFlowMpId";
+           leaf openFlowMpId {
+             type openflow-mp-id ;
+             mandatory true;
+             description "Pipeline metadata associating PDU with remote MEP.";
+           }
+           leaf mipId {
+             type string ;
+             mandatory true;
+           }
+         }
+
+        } // case mep
+
+        case mip {
+
+         list Local_MIP {
+           key "openFlowMpId";
+           leaf openFlowMpId {
+             type openflow-mp-id;
+             mandatory true;
+           }
+           leaf mipId {
+             type string ;
+             mandatory true;
+           }
+           leaf mipType {
+             type mip-type ;
+             mandatory true;
+           }
+           leaf nodeId {
+             type uint32 ;
+             mandatory true;
+           }
+           leaf ifNum {
+             type uint32;
+             mandatory true;
+           }
+         }
+
+        } // case mip
+
+       } //mep-or-mip
+       } // meg
+
+       list MLP_ProtectionGroup {
+         key "resource-id";
+
+         uses "of-config:OFResourceType" ;
+
+         leaf index {
+           type uint32;
+           mandatory true;
+           description "The object indicates the index of the MLP_ProtectionGroup";
+         }
+
+         leaf architecture {
+           type protection-architecture;
+           mandatory true;
+         }
+
+         leaf scheme{
+           type protection-scheme ;
+           mandatory true;
+         }
+
+         leaf name {
+           type string ;
+           mandatory true;
+           description "The object indicates the name of the MLP_ProtectionGroup";
+         }
+
+         leaf revertive {
+           type boolean ;
+           default true;
+         }
+
+         leaf waitToRestore {
+           type uint16;
+           default "5";
+           description "Units are in minutes.";
+         }
+
+         leaf adminStatus {
+           type enumeration {
+             enum "disable" {
+               value 0;
+             }
+             enum "enable" {
+               value 1;
+             }
+           }
+           default "disable";
+         }
+
+         leaf holdOffTimer {
+           type uint16;
+           description "Units are in in seconds";
+           mandatory true;
+         }
+
+         leaf layer {
+           type enumeration {
+             enum "pw" {
+               value 0;
+               description "The object indicates protection at the pw (vc) level";
+             }
+             enum "lsp" {
+               value 1;
+               description "The object indicates protection at the path (tunnel) level";
+             }
+           }
+           default "lsp";
+         }
+
+         leaf psCommand {
+           type enumeration {
+             enum "noCmd" {
+               value 1;
+             }
+             enum "clear" {
+               value 2;
+             }
+             enum "lockoutOfProtection" {
+               value 3;
+             }
+             enum "forcedSwitchWorkToProtect" {
+               value 4;
+             }
+             enum "manualSwitchWorkToProtect" {
+               value 5;
+             }
+           }
+           mandatory true;
+         }
+
+         container MLP_ProtectionGroup_Status {
+           config false;
+           description "MLP Protection Group Status";
+           uses "protection-status";
+         }
+          
+         list mlp-head-end-config {
+           key "liveness-logical-port";
+           description "MLP Head End Config";
+           uses "mlp-config" ;
+           leaf liveness-logical-port {
+             type uint64;
+           }
+           leaf-list mep {
+             type leafref {
+               path "/of-config:capable-switch/of-config:resources/G.8113.1_MEG/Local_MEP/openFlowMpId" ;
+             }
+             description "MEP being protected";
+           }
+         } // mlp-head-end-config
+       } // mlp-protection-group     
+  } // augment
+
+augment "/of-config:capable-switch/of-config:logical-switches/of-config:switch/of-config:resources" {
+
+       leaf-list Ethernet_MEG {
+         type leafref {
+           path "/of-config:capable-switch/of-config:resources/Ethernet_MEG/resource-id";
+         }
+         description "Ethernet MEGs used by this logical switch.";
+       }
+       leaf-list G.8113.1_MEG {
+         type leafref {
+           path "/of-config:capable-switch/of-config:resources/G.8113.1_MEG/resource-id";
+         }
+         description "G.8113.1 MEGs used by this logical switch.";
+       }
+       leaf-list MLP_ProtectionGroup {
+         type leafref {
+           path "/of-config:capable-switch/of-config:resources/MLP_ProtectionGroup/resource-id";
+         }
+         description "MLP_ProtectionGroups used by this logical switch.";
+       }
+  } // augment
+
+}  // module
+

--- a/yang-20191230/of-config-1.2-sptn-port-ext.yang
+++ b/yang-20191230/of-config-1.2-sptn-port-ext.yang
@@ -1,0 +1,480 @@
+module of-config-1.2-sptn-port-ext {
+  namespace 'http://chinamobile.com.cn/sdn/sptn/sbi/schema/port/ext' ;
+  prefix "sptn-port-ext";
+
+  import of-config-1.2 { prefix of-config; }
+
+  organization "SPTN Working Group";
+  contact "SPTN OpenFlow Extensions";
+  description "SPTN Port Extensions Yang Module";
+
+  revision "2019-12-27" {
+    description "initial";
+    reference "sptn openflow extensions draft";
+  }
+
+  typedef als-control-mode-type {
+      type enumeration {
+          enum "open" {
+              value 1;
+          }
+          enum "shutdown" {
+              value 2;
+          }
+          enum "als" {
+              value 3;
+          }  
+       }
+  }
+
+  typedef loopback-type {
+      type enumeration {
+          enum "innerLoopback" {
+              value 1;
+          }
+          enum "externalLoopback" {
+              value 2;
+          } 
+          enum "noLoopback" {
+              value 3;
+          }
+      }
+  }
+
+  typedef port-speed-type {
+      type enumeration {
+          enum "E1" {
+              value 1;
+          }
+          enum "STM-1" {
+              value 2;
+          } 
+      } 
+  }
+
+  typedef vlan-tag-type {
+    type enumeration {
+      enum "tag" {
+          value 1;
+      }
+      enum "untag" {
+          value 2;
+      } 
+    }
+  }
+
+  typedef sdh-port-type {
+    type enumeration {
+      enum "STM-1" {
+          value 1;
+      }
+      enum "STM-4" {
+          value 2;
+      }
+      enum "STM-16" {
+          value 3;
+      }  
+    }
+  }
+
+  typedef enable-type {
+    type enumeration {
+      enum "enable" {
+          value 1;
+      }
+      enum "disable" {
+          value 2;
+      } 
+      enum "autoEnable" {
+          value 3;
+      } 
+    } 
+  }
+
+  typedef vc-type {
+    type enumeration {
+      enum "vc12" {
+          value 1;
+      }
+      enum "vc3" {
+          value 2;
+      }  
+    } 
+  }
+
+  typedef ces-clock-mode-type {
+    type enumeration {
+      enum "local" {
+        value 1;
+      }
+      enum "dcr" {
+        value 2;
+      } 
+      enum "acr" {
+        value 3;
+      } 
+      enum "loopback" {
+        value 4;
+      } 
+    } 
+  }
+
+  typedef frame-mode-type {
+    type enumeration {
+      enum "unframed" {
+        value 1;
+      }
+      enum "pcm30" {
+        value 2;
+      } 
+      enum "pcm31" {
+        value 3;
+      }  
+    } 
+  }
+  
+  grouping tdm-e1-status-grouping {
+    container tdm-e1-status {
+      description
+        "The tdm performance status.";
+      leaf es {
+        type uint64;
+        config false;
+        description
+          "The error seconds.";
+      }
+      leaf ses {
+        type uint64;
+        config false;
+        description
+          "The severely error seconds.";
+      }
+
+      leaf uas {
+        type uint64;
+        config false;
+        description
+          "The unavailable seconds."; 
+      }
+
+      leaf cv {
+        type uint64;
+        config false;
+        description
+          "The Code Violation."; 
+      }
+    }
+  }
+
+  grouping tdm-grouping {
+    container tdm {
+      description
+        "The attributes of tdm.";
+
+      leaf pipe-enable {
+        type boolean;
+      
+        description
+          ""; 
+      }
+      leaf pipe-num {
+        type uint16;
+      
+        description
+          "";
+      }
+      leaf speed-type {
+        type port-speed-type;
+      
+        description
+          "The value is E1.";
+      }
+      leaf frame-mode {
+        type frame-mode-type;
+      
+        description
+          "The frame mode.";
+      }
+      leaf crc-enable {
+        type enable-type;
+      
+        description
+          "1:enable 2:disable";
+      }
+      leaf clock-recovery-enable {
+        type enable-type;
+      
+        description
+          "1:enable 2:disable";
+      }
+      leaf ces-clock-mode {
+        type ces-clock-mode-type;
+      
+        description
+          "";
+      }
+      uses tdm-status-grouping;
+    }
+  }
+
+  grouping port-ext-grouping {
+      leaf vlan-tag {
+        type vlan-tag-type;
+      
+        description
+          "tag,untag";
+      }
+      uses port-loopback-grouping;
+      uses port-als-grouping;
+
+  }
+
+  grouping port-loopback-grouping {
+        container port-loopback {
+          description
+            "The attributes of loopback.";
+          leaf loop-type {
+            type loopback-type;
+          
+            description
+              "";
+          } 
+        }
+  }
+
+  grouping port-als-grouping {
+      container port-als {
+        description
+          "The attributes of eth port als";
+
+          leaf control-mode {
+            type als-control-mode-type;
+          
+            description
+              "The control mode type.";
+          }
+          leaf enable {
+            type boolean;
+          
+            description
+              "true:enable false:disable";
+          }
+          leaf control-status {
+            type als-control-mode-type;
+            config false;
+            description
+              "";
+          }
+        
+      }
+  }
+
+  grouping sdh-port-grouping {
+    leaf sdh-port-type {
+      type sdh-port-type;
+      config false;
+      description
+        "The type of sdh port.STM-1,STM-4,STM-16.";
+    }
+    leaf monitor-enable {
+      type enable-type;
+    
+      description
+        "Sdh port monitor enable.1:enable 2:disable 3:autoEnable.";
+    }
+    leaf dcc-enable {
+      type enable-type;
+    
+      description
+        "DCC enable.1:enable 2:disable";
+    }
+    leaf dcc-byte-select {
+      type uint32;
+    
+      description
+        "";
+    }
+
+    leaf path-num {
+      type uint16;
+    
+      description
+        "The num of path.";
+    }
+    uses regx-overhead-grouping;
+  }
+
+  grouping regx-overhead-grouping {
+    container regx-overhead {
+      description
+        "The information of regx overhead.";
+      leaf j0-tx {
+        type string;
+      
+        description
+          "The transmit J0 bytes of regeneration section.";
+      }
+      leaf j0-exp-tx {
+        type string;
+      
+        description
+          "The transmit exception J0 bytes of regeneration section.";
+      }
+      leaf j0-rx {
+        type string;
+      
+        description
+          "The receive J0 bytes of regeneration section.";
+      }
+    }
+  }
+
+  container high-order-path-config {
+      description
+        "The information of high path.";
+    list sdh-high-path{
+      key "high-path-id";
+    
+      description
+        "";
+    
+      leaf high-path-id {
+        type uint32;
+    
+        description
+          "";
+      }
+      uses high-order-path-grouping;
+    }
+      
+  }
+
+  grouping high-order-path-grouping {
+    leaf j1-tx {
+      type string;
+      
+      description
+          "The transmit J1 bytes of regeneration section.";
+    }
+    leaf j1-exp-tx {
+        type string;
+      
+        description
+          "The transmit exception J1 bytes of regeneration section.";
+    }
+    leaf j1-rx {
+        type string;
+      
+        description
+          "The receive J1 bytes of regeneration section.";
+    }
+    leaf c2-tx {
+        type string;
+      
+        description
+          "The transmit C2 bytes of regeneration section.";
+    }
+    leaf c2-exp-tx {
+        type string;
+      
+        description
+          "The transmit C2 exp bytes of regeneration section.";
+    }
+    leaf c2-rx {
+        type string;
+      
+        description
+          "The receive C2 bytes of regeneration section.";
+    }
+    leaf port {
+      type leafref {
+        path "/of-config:capable-switch/of-config:resources/of-config:port/of-config:resource-id";
+      }
+      description
+      "The related port ref of the high order path. ";
+    }
+  }
+
+  container lower-order-path-vcc {
+      description
+        "The information of lower path.";
+    list sdh-lower-path{
+      key "vcc-id";
+    
+      description
+        "";
+    
+      leaf vcc-id {
+        type uint32;
+    
+        description
+          "";
+      }
+      uses lower-order-path-grouping;
+    }
+      
+  }
+
+  grouping lower-order-path-grouping {
+    leaf port {
+      type leafref {
+        path "/of-config:capable-switch/of-config:resources/of-config:port/of-config:resource-id";
+      }
+      description
+      "The related port ref of the lower order path. ";
+    }
+    leaf high-path-id {
+      type string;
+      description
+      "The related high path id of the lower order path. ";
+    }
+    leaf vc-type {
+      type vc-type;
+    
+      description
+        "vc12,vc3";
+    }
+    leaf j2-tx {
+      type string;
+    
+      description
+        "";
+    }
+    leaf j2-exp-tx {
+      type string;
+    
+      description
+        "";
+    }
+    leaf j2-rx {
+      type string;
+    
+      description
+        "";
+    }
+    leaf v5-rx {
+      type string;
+    
+      description
+        "";
+    }
+    leaf v5-tx {
+      type string;
+    
+      description
+        "";
+    }
+
+  }
+
+  augment "/of-config:capable-switch/of-config:resources/of-config:port" {
+      uses tdm-grouping;
+  }  
+
+  augment "/of-config:capable-switch/of-config:resources/of-config:port" {
+      uses port-ext-grouping;
+  }
+  augment "/of-config:capable-switch/of-config:resources/of-config:port" {
+      uses sdh-port-grouping;
+  }  
+}

--- a/yang-20191230/of-config-1.2-sptn-qos.yang
+++ b/yang-20191230/of-config-1.2-sptn-qos.yang
@@ -1,0 +1,142 @@
+module of-config-1.2-sptn-qos {
+     namespace 'http://chinamobile.com.cn/sdn/sptn/sbi/schema/qos' ;
+     prefix "sptn-qos";
+
+     import of-config-1.2 { prefix of-config; }
+     import ietf-yang-types { prefix yang; }
+     import of-config-1.2-sptn-oam { prefix sptn-oam; }
+
+     organization "SPTN Working Group";
+     contact "SPTN OpenFlow Extensions";
+     description "SPTN QOS Yang Module";
+
+     revision "2016-02-08" {
+       description "initial";
+       reference "sptn openflow extensions draft";
+     }
+
+     typedef port-scheduling-mode{
+       type enumeration {
+         enum "SP" {
+           value 1;
+           description "Strict Priority";
+         }
+         enum "RR" {
+           value 2;
+           description "Round Robin";
+         }
+         enum "WRR" {
+           value 3;
+           description "Weighted Round Robin";
+         }
+         enum "WDRR" {
+           value 4;
+           description "Weighted Deficit Round Robin";
+         }
+         enum "SP_WRR" {
+           value 5;
+           description "Strict Priority Plus Weighted Round Robin";
+         }
+         enum "SP_WDRR" {
+           value 6;
+           description "Strict Priority Plus Weighted Deficit Round Robin";
+         }
+       }
+     }
+
+     typedef queue-congestion-mode{
+       type enumeration {
+         enum "TAIL_DROP" {
+           value 1;
+           description "Tail drop (SPTN_QDC_TAIL_DROP)";
+         }
+         enum "WRED" {
+           value 2;
+           description "Weighted Random Early Detection (SPTN_QDC_WRED).";
+         }
+      }
+    }
+
+    grouping wred-drop-curve {
+       description "Curve points for WRED.";
+       leaf start {
+         type uint32;
+         description "The queue utilization at which random early detection begins, as a percent.";
+       }
+       leaf end {
+         type uint32;
+         description "The queue utilization after which packets are always dropped, as a percent.";
+       }
+       leaf slope {
+         type uint32;
+         description "The slope of the curve, as the horizontal ratio (N to 1).";
+       }
+    }
+
+
+augment "/of-config:capable-switch/of-config:resources/of-config:port" {
+
+       leaf scheduling-mode {  
+         type port-scheduling-mode;
+         }
+
+    } // augment
+
+augment "/of-config:capable-switch/of-config:resources/of-config:queue/of-config:properties" {
+
+         leaf scheduling-priority {
+           type "sptn-oam:priority" ;
+           description "Priority if needed for SP scheduling modes.";
+         }
+
+         leaf scheduling-weight {
+           type uint32;
+           description "Weight if needed for WRR or WDRR scheduling mode.";
+         }
+
+         leaf congestion-mode {
+           type queue-congestion-mode;
+           default "TAIL_DROP";
+         }
+
+         choice td-or-wred {
+
+         case wred {
+
+         container green-drop-curve {
+           when "congestion-mode = WRED" ;
+           uses wred-drop-curve ;
+         }
+
+         container yellow-drop-curve {
+           when "congestion-mode = WRED" ;
+           uses wred-drop-curve ;
+         }
+
+         container red-drop-curve {
+           when "congestion-mode = WRED" ;
+           uses wred-drop-curve ;
+         }
+
+         } // wred
+
+         case td {
+
+         leaf drop-threshold {
+           when "congestion-mode = TAIL_DROP" ;
+           type uint32 {
+             range "1..100";
+           }
+           default "100" ;
+           description "maximum queue size for tail drop.";
+         }
+
+         } // td
+         } // td-or-wred
+
+
+  } // augment
+
+
+}  // module
+

--- a/yang-20191230/of-config-1.2.yang
+++ b/yang-20191230/of-config-1.2.yang
@@ -1,0 +1,1897 @@
+module of-config-1.2 {
+  namespace "urn:onf:config:yang";
+  prefix of-config;
+
+  import ietf-yang-types { prefix yang; }
+  import ietf-inet-types { prefix inet; }
+
+  organization "ONF Config Management Group";
+
+  contact "mailto:info@opennetworking.org";
+
+  description
+    "This module contains a collection of YANG definitions for
+     configuring OpenFlow datapaths. It is part of the OF-CONFIG
+     specification.";
+
+  revision 2013-10-05 {
+    description
+       "This version of this YANG Module is part of the OF-CONFIG
+        1.2 specification; please see the specification itself for
+        details.";
+
+    reference
+      "OF-CONFIG 1.2";
+  }
+
+  revision 2011-12-07 {
+    description
+      "First Version";
+
+    reference
+      "OF-CONFIG 1.1.1";
+  }
+
+/*****************************************************************
+ * Type definitions
+ *****************************************************************/
+
+  typedef OFConfigId {
+    type string;
+    description
+      "Generic type of an identifier in OF-CONFIG";
+  }
+
+  typedef OFConfigurationPointProtocolType {
+    type enumeration {
+      enum "ssh";
+      enum "soap";
+      enum "tls";
+      enum "beep";
+    }
+    description
+      "Possible protocols to connect ot an OF Configuration Point";
+  }
+
+  typedef OFOpenFlowVersionType {
+    type enumeration {
+      enum "not-applicable";
+      enum "1.0";
+      enum "1.1";
+      enum "1.2";
+      enum "1.3";
+    }
+    description
+      "This enumeration contains all OpenFlow major versions supported by
+       this module";
+  }
+
+  typedef datapath-id-type {
+    type string {
+      pattern '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){7}';
+    }
+    description
+      "The datapath-id type represents an OpenFlow
+       datapath identifier.";
+  }
+
+  typedef OFTenthOfAPercentType {
+    type uint16 {
+      range "0..1000";
+    }
+    units "1/10 of a percent";
+    description
+      "This type defines a value in tenth of a percent.";
+  }
+
+  typedef OFUpDownStateType {
+    type enumeration {
+      enum up;
+      enum down;
+    }
+    description
+      "Type to specify state information for a port or a
+       connection.";
+  }
+
+  typedef OFPortRateType {
+    type enumeration {
+      enum 10Mb-HD;
+      enum 10Mb-FD;
+      enum 100Mb-HD;
+      enum 100Mb-FD;
+      enum 1Gb-HD;
+      enum 1Gb-FD;
+      enum 10Gb;
+      enum 40Gb;
+      enum 100Gb;
+      enum 1Tb;
+      enum other;
+    }
+    description
+      "Type to specify the rate of a port including the
+       duplex transmission feature. Possible rates are 10Mb, 100Mb,
+       1Gb, 10Gb, 40Gb, 100Gb, 1Tb or other. Rates of 10Mb, 100Mb
+       and 1 Gb can support half or full duplex transmission.";
+  }
+
+  typedef OFActionType {
+    type enumeration {
+      enum output;
+      enum copy-ttl-out;
+      enum copy-ttl-in;
+      enum set-mpls-ttl;
+      enum dec-mpls-ttl;
+      enum push-vlan;
+      enum pop-vlan;
+      enum push-mpls;
+      enum pop-mpls;
+      enum set-queue;
+      enum group;
+      enum set-nw-ttl;
+      enum dec-nw-ttl;
+      enum set-field;
+    }
+    description
+      "The types of actions defined in OpenFlow Switch
+       Specification versions 1.2, 1.3, and 1.3.1";
+  }
+
+  typedef OFInstructionType {
+    type enumeration {
+      enum apply-actions;
+      enum clear-actions;
+      enum write-actions;
+      enum write-metadata;
+      enum goto-table;
+    }
+    description
+      "The types of instructions defined in OpenFlow
+       Switch Specification versions 1.2, 1.3, and 1.3.1.";
+  }
+
+  typedef OFMatchFieldType {
+    type enumeration {
+      enum input-port;
+      enum physical-input-port;
+      enum metadata;
+      enum ethernet-dest;
+      enum ethernet-src;
+      enum ethernet-frame-type;
+      enum vlan-id;
+      enum vlan-priority;
+      enum ip-dscp;
+      enum ip-ecn;
+      enum ip-protocol;
+      enum ipv4-src;
+      enum ipv4-dest;
+      enum tcp-src;
+      enum tcp-dest;
+      enum udp-src;
+      enum udp-dest;
+      enum sctp-src;
+      enum sctp-dest;
+      enum icmpv4-type;
+      enum icmpv4-code;
+      enum arp-op;
+      enum arp-src-ip-address;
+      enum arp-target-ip-address;
+      enum arp-src-hardware-address;
+      enum arp-target-hardware-address;
+      enum ipv6-src;
+      enum ipv6-dest;
+      enum ipv6-flow-label;
+      enum icmpv6-type;
+      enum icmpv6-code;
+      enum ipv6-nd-target;
+      enum ipv6-nd-source-link-layer;
+      enum ipv6-nd-target-link-layer;
+      enum mpls-label;
+      enum mpls-tc;
+    }
+    description
+      "The types of match field defined in OpenFlow Switch Specification
+       versions 1.2, 1.3, and 1.3.1.";
+  }
+
+  typedef OFExperimenterId {
+    type uint32;
+    description
+      "The experimenter field is a 32-bit value that uniquely identifies the
+       experimenter. If the most significant byte is zero, the next
+       three bytes are the experimenter's IEEE OUI. If the most
+       significant byte is not zero, it is a value allocated by the
+       Open Networking Foundation.";
+  }
+
+  typedef hex-binary {
+    type binary;
+    description
+      "Hex binary encoded string";
+    reference
+      "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/datatypes.html#hexBinary";
+  }
+
+/*****************************************************************
+ * Groupings
+ *****************************************************************/
+
+  grouping OFConfigurationPointType {
+    description
+      "Representation of an OpenFlow Configuration Point.
+       Instances of the Configuration Point class SHOULD be stored 
+       persistently across reboots of the OpenFlow Capable Switch.
+    
+       When a connection is established between an OpenFlow Capable 
+       Switch and a Configuration Point the switch  MUST store the 
+       connection information in an instance of the Configuration 
+       Point class. If such an instance does not exist, the OpenFlow
+       Capable Switch MUST create an instance where it then stores 
+       the connection information.
+    
+       An OpenFlow Capable Switch that cannot initiate a connection 
+       to a configuration point does not have to implement the 
+       Configuration Point class. It SHOULD block attempts to write
+       to instances of the Configuration Point class with NETCONF 
+       <edit-config> operations.";
+
+    leaf id {
+      type OFConfigId;
+      mandatory true;
+      description
+	"A unique but locally arbitrary identifier that
+         identifies a Configuration Point within the context of an 
+         OpenFlow Capable Switch.";
+    }
+
+    leaf uri {
+      type inet:uri;
+      mandatory true;
+      description
+	"A locator of the Configuration Point.  It 
+         identifies the location of the Configuration Point as a 
+         service resource and MUST include all information necessary
+         for the OpenFlow Capable Switch to connect to the 
+         Configuration Point or re-connect to it should it become 
+         disconnected.  Such information MAY include, for example, 
+         protocol, fully qualified domain name, IP address, port 
+         number, etc.";
+    }
+
+    leaf protocol {
+      type OFConfigurationPointProtocolType;
+      default "ssh";
+      description
+	"The transport protocol that the Configuration
+         Point uses when communicating via NETCONF with the OpenFlow
+         Capable Switch.";
+
+      reference
+	"The mappings of NETCONF to different transport
+         protocols are defined in RFC 6242 for SSH, RFC 4743 for
+         SOAP, RFC 4744 for BEEP, and RFC 5539 for TLS";
+    }
+  }
+
+  grouping OFLogicalSwitchType {
+    description
+      "This grouping specifies all properties of an OpenFlow
+       Logical Switch.";
+
+    leaf id {
+      type OFConfigId;
+      mandatory true;
+      description
+	"A unique but locally arbitrary identifier that
+         identifies a Logical Switch within the context of an
+         OpenFlow Capable Switch. It MUST be persistent across
+         reboots of the OpenFlow Capable Switch.";
+    }
+
+    container capabilities {
+      config false;
+      description
+	"This element contains all capability items that
+         an OpenFlow Logical Switch MAY implement.";
+
+      uses OFLogicalSwitchCapabilitiesType;
+    }
+
+    leaf datapath-id {
+      type datapath-id-type;
+      mandatory true;
+      description
+	"The datapath identifier of the Logical Switch
+         that uniquely identifies this Logical Switch within the
+         context of all OpenFlow Controllers associated with the
+         OpenFlow Logical Switch.  The datapath identifier is a
+         string value that MUST be formatted as a sequence of 8
+         2-digit hexadecimal numbers that are separated by colons,
+         for example, '01:23:45:67:89:ab:cd:ef'.  When processing a
+         datapath identifier, the case of the decimal digits MUST be
+         ignored.";
+    }
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+	"This element indicates the administrative state
+         of the OpenFlow Logical Switch.  A value of 'false' means
+         the OpenFlow Logical Switch MUST NOT communicate with any 
+         OpenFlow Controllers, MUST NOT conduct any OpenFlow 
+         processing, and SHOULD NOT be utilizing computational or 
+         network resources of the underlying platform.";
+     }
+ 
+   leaf check-controller-certificate {
+      type boolean;
+      default false;
+      description
+	"This element indicates the behavior of the 
+         OpenFlow Logical Switch when connecting to an OpenFlow
+         Controller.  
+      
+         If set to value 'false', the logical switch will connect to
+         a controller without checking any controller certificate.  
+      
+         If set to value 'true', then the logical switch will
+         connect to a controller with element <protocol> set to
+         'TLS', only if the controller provides a certificate that
+         can be verified with one of the certificates stored in the
+         list called external-certificates in the OpenFlow Capable
+         Switch.  
+      
+         If a certificate cannot be validated, the OpenFlow Logical 
+         Switch MUST terminate communication with the corresponding
+         OpenFlow Controller, MUST NOT conduct any OpenFlow
+         processing on requests of this OpenFlow controller, and 
+         SHOULD NOT further utilize any computational or network 
+         resources of for dealing with this connection.
+      
+         If set to value 'true', the OpenFlow Logical Switch MUST
+         NOT connect to any OpenFlow Controller that does not
+         provide a certificate. This implies that it cannot connect
+         to an OpenFlow controller that has the value of element
+         protocol set to 'TCP'. Only connections with protocol 'TLS'
+         are possible in this case.";
+    }
+
+    leaf lost-connection-behavior {
+      type enumeration {
+        enum failSecureMode;
+        enum failStandaloneMode;
+      }
+      default failSecureMode;
+      description
+	"This element indicates the the behavior of the 
+         OpenFlow Logical Switch in case it loses contact with all 
+         OpenFlow Controllers.  There are two alternative modes in
+         such a case: fails secure mode and fail standalone mode as
+         defined by the OpenFlow protocol specification version 1.2,
+         section 6.4.  These are the only allowed values for this
+         element. Default is the fail secure mode.";
+    }
+
+    container controllers {
+      description
+	"The list of controllers for this Logical switch.";
+
+      list controller {
+        key "id";
+        description
+	  "The list of OpenFlow Controllers that are 
+           assigned to the OpenFlow Logical Switch.  The switch MUST
+           NOT connect to any OpenFlow Controller that is not
+           contained in this list.";
+
+        uses OFControllerType;
+      }
+    }
+
+    container resources {
+      description
+	"The list of identifiers of all resources of the
+         OpenFlow Capable Switch that the OpenFlow Logical Switch
+         has exclusive or non-exclusive access to.  A resource is 
+         identified by the value of its resource-identifier element.
+         For each resource identifier value in this list, there MUST
+         be an element with a matching resource identifier value in 
+         the resources list of the OpenFlow Capable Switch.
+      
+         Identifiers of this list are contained in elements
+         indicating the type of resource: 'port', 'queue',
+         'certificate', or 'flow-table'.  Depending on the type,
+         different constraints apply.  These are specified in
+         separate descriptions per type.";
+
+      leaf-list port {
+        type leafref {
+          path "/capable-switch/resources/port/resource-id";
+        }
+        description
+	  "A resource identifier of a port of the OpenFlow Capable
+           Switch that the OpenFlow Logical Switch has exclusive access to.
+
+          Elements in this list MUST be unique. This means each
+          port element can only be referenced once.";
+      }
+
+      leaf-list queue {
+        type leafref {
+          path "/capable-switch/resources/queue/resource-id";
+        }
+        description
+	  "A resource identifier of a queue of the OpenFlow Capable Switch
+           that the OpenFlow Logical Switch has exclusive access to.
+
+           Elements in this list MUST be unique. This means each
+           queue element can only be referenced once.";
+      }
+
+      leaf certificate {
+        type leafref {
+          path "/capable-switch/resources/owned-certificate/resource-id";
+        }
+        description
+	  "The resource identifier of the owned certificate in the OpenFlow Capable
+          Switch that the OpenFlow Logical Switch uses to identify
+          itself.  This element MUST NOT occur more than once in an
+          OpenFlow Logical Switch's resource list.
+        
+          If no such element is in an OpenFlow Logical Switch's resource
+          list, then the OpenFlow Logical Switch does not authenticate
+          itself towards an OpenFloe Controller with a certificate.  If
+          this element is present, then the OpenFlow Logical Switch MUST
+          provide this certificate for authentication to an OpenFlow
+          Controller when setting up a TLS connection.
+        
+          For TCP connections this element is irrelevant.";
+      }
+
+      leaf-list flow-table {
+        type leafref {
+          path "/capable-switch/resources/flow-table/table-id";
+        }
+        description
+	  "A resource identifier of a flow table of the OpenFlow Capable
+           Switch that the OpenFlow Logical Switch has exclusive access to.
+
+           Elements in this list MUST be unique. This means each
+           flow-table element can only be referenced once.";
+      }
+    }
+  }
+  
+  grouping OFLogicalSwitchCapabilitiesType {
+    description
+      "This grouping specifies all properties of an OpenFlow logical switch's
+      capabilities.";
+
+    leaf max-buffered-packets {
+      type uint32;
+      description
+	"The maximum number of packets the logical switch
+         can buffer when sending packets to the controller using
+         packet-in messages.";
+    }
+
+    leaf max-tables {
+      type uint8;
+      description
+        "The number of flow tables supported by the logical switch.";
+    }
+
+    leaf max-ports {
+      type uint32;
+      description
+        "The number of flow tables supported by the logical switch.";
+    }
+
+    leaf flow-statistics {
+      type boolean;
+      default false;
+      description
+	"Specifies if the logical switch supports flow statistics.";
+    }
+
+    leaf table-statistics {
+      type boolean;
+      default false;
+      description
+	"Specifies if the logical switch supports table statistics.";
+    }
+
+    leaf port-statistics {
+      type boolean;
+      default false;
+      description
+	"Specifies if the logical switch supports port statistics.";
+    }
+
+    leaf group-statistics {
+      type boolean;
+      default false;
+      description
+	"Specifies if the logical switch supports group statistics.";
+    }
+
+    leaf queue-statistics {
+      type boolean;
+      default false;
+      description
+	"Specifies if the logical switch supports queue statistics.";
+    }
+
+    leaf reassemble-ip-fragments {
+      type boolean;
+      default false;
+      description
+	"Specifies if the logical switch supports reassemble IP fragments.";
+    }
+
+    leaf block-looping-ports {
+      type boolean;
+      default false;
+      description
+	"'true' indicates that a switch protocol outside of OpenFlow, such as
+         802.1D Spanning Tree, will detect topology loops and block ports
+         to prevent packet loops.";
+    }
+
+    container reserved-port-types {
+      description
+	"Specify generic forwarding actions such as sending to the controller,
+         flooding, or forwarding using non-OpenFlow methods, such as
+         'normal' switch processing.";
+
+      reference
+	"The types of reserved ports are defined in OpenFlow Switch Specification
+         versions 1.2, 1.3, and 1.3.1.";
+
+      leaf-list type {
+        type enumeration {
+          enum all;
+          enum controller;
+          enum table;
+          enum inport;
+          enum any;
+          enum normal;
+          enum flood;
+        }
+      }
+    }
+
+    container group-types {
+      description
+	"Specify the group types supported by the logical switch.";
+
+      reference
+	"The types of groups are defined in OpenFlow Switch Specification
+         versions 1.2, 1.3, and 1.3.1.";
+
+      leaf-list type {
+        type enumeration {
+          enum all;
+          enum select;
+          enum indirect;
+          enum fast-failover;
+        }
+      }
+    }
+
+    container group-capabilities {
+      description
+	"Specify the group capabilities supported by the logical switch.";
+
+      reference
+	"The types of group capability are defined in OpenFlow Switch
+         Specification versions 1.2, 1.3, and 1.3.1.";
+
+      leaf-list capability {
+        type enumeration {
+          enum select-weight;
+          enum select-liveness;
+          enum chaining;
+          enum chaining-check;
+        }
+      }
+    }
+
+    container action-types {
+      description
+	"Specify the action types supported by the logical switch.";
+
+      leaf-list type {
+        type OFActionType;
+      }
+    }
+
+    container instruction-types {
+      description
+	"Specify the instruction types supported by the logical switch.";
+
+      leaf-list type {
+        type OFInstructionType;
+      }
+    }
+  }
+
+  grouping OFControllerType {
+    description
+      "This grouping specifies all properties of an OpenFlow Logical Switch
+       Controller.";
+
+    leaf id {
+      type OFConfigId;
+      mandatory true;
+      description
+	"A unique but locally arbitrary identifier that uniquely identifies an
+         OpenFlow Controller within the context of an OpenFlow Capable
+         Switch.  It MUST be persistent across reboots of the OpenFlow
+         Capable Switch.";
+    }
+
+    leaf role {
+      type enumeration {
+        enum master;
+        enum slave;
+        enum equal;
+      }
+      default equal;
+
+      description
+	"This element indicates the role of the OpenFlow Controller. Semantics of
+         these roles are specified in the OpenFlow specifications 1.0 -
+         1.3.1.  It is RECOMMENDED that the roles of controllers are not
+         configured by OF-CONFIG 1.1.1 but determined using the OpenFlow
+         protocol.  OpenFlow Controllers configured by OF-CONFIG 1.1.1
+         have the default role 'equal'.  A role other than 'equal' MAY be
+         assigned to a controller.  Roles 'slave' and 'equal' MAY be
+         assigned to multiple controllers.  Role 'master' MUST NOT be
+         assigned to more than one controller.";
+    }
+
+    leaf ip-address {
+      type inet:ip-address;
+      mandatory true;
+      description
+	"The IP address of the OpenFlow Controller.  This IP address is used by
+         the OpenFlow Logical Switch when connecting to the OpenFlow
+         Controller.";
+    }
+
+    leaf port {
+      type inet:port-number;
+      default 6633;
+      description
+	"The TCP port number at the OpenFlow Controller.  This port number is
+         used by the OpenFlow Logical Switch when connecting to the
+         OpenFlow Controller using TCP or TLS.  The default value is
+         6633.";
+    }
+
+    leaf local-ip-address {
+      type inet:ip-address;
+      description
+	"The local IP address of the OpenFlow Logical Switch when connecting to
+        this OpenFlow Controller.  It is the source IP address of
+        packets sent to this OpenFlow Controller.  If present, this
+        element overrides any default IP address.
+        
+        This element is optional. Attempts to set this element to an IP
+        address that cannot be used by the OpenFlow Logical Switch MUST
+        result in an 'bad-element' error with type 'application'. The
+        <error-info> element MUST contain the name of this element in
+        the <bad-element> element.";
+    }
+
+    leaf local-port {
+      type inet:port-number;
+      description
+	"The local TCP port number of the OpenFlow Logical Switch when connecting
+         to this OpenFlow Controller.  It is the source TCP port number
+         of packets sent to this OpenFlow Controller.  If this element is
+         not present, then the port number is chosen arbitrarily by the
+         OpenFlow Logical Switch.
+      
+         This element is optional. Attempts to set this element to a
+         port number that cannot be used by the OpenFlow Logical
+         Switch MUST result in an 'bad-element' error with type
+         'application'. The <error-info> element MUST contain the
+         name of this element in the <bad-element> element.";
+    }
+
+    leaf protocol {
+      type enumeration {
+        enum "tcp";
+        enum "tls";
+      }
+      default "tls";
+      description
+	"The default protocol that the OpenFlow Logical Switch uses to connect to
+         this OpenFlow Controller.";
+    }
+
+    container state {
+      config false;
+      description
+	"This container holds connection state information that indicate the
+         connection state of the OpenFlow Logical Switch and the OpenFlow
+         protocol version used for the connection.";
+
+      leaf connection-state {
+        type OFUpDownStateType;
+        description
+	  "This object indicates the connections state of the OpenFlow Logical
+           Switch to this controller.";
+      }
+      leaf current-version {
+        type OFOpenFlowVersionType;
+        description
+	  "This object indicates the version of the OpenFlow protocol used between
+           the OpenFlow Logical Switch and this Controller.  If element
+           connection-state has value 'up', then this element indicates
+           the actual version in use.  If element connection-state has
+           value 'down', then this element indicates the version number
+           of the last established connection with this OpenFlow
+           Controller.  The value of this element MAY be persistent
+           across reboots of the OpenFlow Logical Switch in such a case.
+           If element connection-state has value 'down'and there is no
+           information about previous connections to this OpenFlow
+           controller, then this element is not present.";
+      }
+
+      leaf-list supported-versions {
+        type OFOpenFlowVersionType;
+        description
+	  "This list of elements includes one entry for each OpenFlow protocol
+           version that this OpenFlow controller supports.  It SHOULD
+           contain all.";
+      }
+
+      leaf local-ip-address-in-use {
+        type inet:ip-address;
+        description
+	  "The local IP address of the OpenFlow Logical Switch when connecting to
+           this OpenFlow Controller.  It is the source IP address of
+           packets sent to this OpenFlow Controller.  If present, this
+           element overrides any default IP address.";
+      }
+
+      leaf local-port-in-use {
+        type inet:port-number;
+        description
+	  "The local TCP port number of the OpenFlow Logical Switch.  If element
+           connection-state has value 'up', then this element indicates
+           the actual port number in use.  If element connection-state
+           has value 'down', then this element indicates the port number
+           used for the last attempt to establish a connection with this
+           OpenFlow Controller.???  When connecting to this OpenFlow
+           Controller, it is the source TCP port number of packets sent
+           to this OpenFlow Controller.  If this element has its defaqult
+           value 0, then port number is chosen arbitrarily by the
+           OpenFlow Logical Switch.";
+      }
+    }
+  }
+
+  grouping OFResourceType {
+    description
+      "This element specifies a generic OpenFlow resource
+       that is used as a basis for specific resources. Even though
+       this element is not used on its own the following rules for
+       NETCONF operations MUST be obeyed also by elemnts using this
+       element.";
+
+    leaf resource-id {
+      type inet:uri;
+      mandatory true;
+      description
+	"A unique but locally arbitrary identifier that uniquely identifies an
+         OpenFlow Port within the context of an OpenFlow Logical Switch.
+         It MUST be persistent across reboots of the OpenFlow Capable
+         Switch.";
+    }
+  }
+
+  grouping OFPortBaseTunnelType {
+    description
+      "A group of common elements that are included in every supported tunnel
+       type. Tunnels are modeled as logical ports.
+
+       One pair of local/remote endpoints must exist for a tunnel
+       configuration.
+
+      Only elements from one choice must exist at a time.";
+ 
+    choice endpoints {
+      mandatory true;
+
+      case v4-endpoints {
+        leaf local-endpoint-ipv4-adress {
+          type inet:ipv4-address;
+          description
+	    "The IPv4 address of the local tunnel endpoint.";
+        }
+
+        leaf remote-endpoint-ipv4-adress {
+          type inet:ipv4-address;
+          description
+	    "The IPv4 address of the remote tunnel endpoint.";
+        }
+      }
+
+      case v6-endpoints {
+        leaf local-endpoint-ipv6-adress {
+          type inet:ipv6-address;
+          description
+	    "The IPv6 address of the local tunnel endpoint.";
+        }
+
+        leaf remote-endpoint-ipv6-adress {
+          type inet:ipv6-address;
+          description
+	    "The IPv6 address of the remote tunnel endpoint.";
+        }
+      }
+
+      case mac-endpoints {
+        leaf local-endpoint-mac-adress {
+          type yang:mac-address;
+          description
+	    "The MAC address of the local tunnel endpoint.";
+        }
+
+        leaf remote-endpoint-mac-adress {
+          type yang:mac-address;
+          description
+	    "The MAC address of the remote tunnel endpoint.";
+        }
+      }
+    }
+  }
+
+  grouping OFPortIPGRETunnelType {
+    description
+      "Properties of a IP-in-GRE tunnel with key, checksum, and sequence number
+      information.";
+
+    uses OFPortBaseTunnelType;
+
+    leaf checksum-present {
+      type boolean;
+      default true;
+      description
+	"Indicates presence of the GRE checksum.";
+    }
+
+    leaf key-present {
+      type boolean;
+      default true;
+      description
+	"Indicates presence of the GRE key.";
+    }
+
+    leaf key {
+      when "../key-present='true'" {
+        description
+	  "This element is only relevant if element key-present of this IP GRE
+          Tunnel has value 'true'.";
+      }
+      type uint32;
+      mandatory true;
+      description
+	"The (optional) key of the GRE tunnel.  It MAY be used to set the
+        OXM_OF_TUNNEL_ID match field metadata in the OpenFlow protocol";
+    }
+
+    leaf sequence-number-present {
+      type boolean;
+      default false;
+      description
+	"Indicates presence of the GRE sequence number.";
+    }
+  }
+
+  grouping OFPortVXLANTunnelType {
+    description
+      "Properties of a VxLAN tunnel.";
+    uses OFPortBaseTunnelType;
+
+    leaf vni-valid {
+      type boolean;
+      default true;
+      description
+	"Indicates how the corresponding flag should be set in packets sent on
+         the tunnel.";
+    }
+
+    leaf vni {
+      type uint32;
+      description
+	"Virtual network identifier assigned to all packets sent on the tunnel.
+         A VxLAN implementation MAY use the this element to set the
+         OXM_OF_TUNNEL_ID match field metadata in the OpenFlow protocol.";
+    }
+
+    leaf vni-multicast-group {
+      type inet:ip-address;
+      description
+	"If IP multicast is used to support broadcast on the tunnel this
+         specifies the corresponding multicast IP address";
+    }
+
+    leaf udp-source-port {
+      type inet:port-number;
+      description
+	"Specifies the outer UDP source port number.  If this element is absent,
+         the port number MAY be chosen dynamically.";
+    }
+
+    leaf udp-dest-port {
+      type inet:port-number;
+      default 4789;
+      description
+	"Specifies the outer UDP destination port number.  It SHOULD
+         be set to 4789, the port number reserved for VxLAN at IANA.";
+    }
+
+    leaf udp-checksum {
+      type boolean;
+      default false;
+      description
+	"Boolean flag to indicate whether or not the outer UDP checksum should be
+         set";
+    }
+  }
+ 
+  grouping OFPortNVGRETunnelType {
+    description
+      "Properties of an NVGRE tunnel.";
+
+    uses OFPortBaseTunnelType;
+
+    leaf vsid {
+      type uint32;
+      description
+	"Specifies the virtual subnet id used to identify packets belonging to
+	 the NVGRE virtual layer-2 network (24 bit)";
+    }
+
+    leaf flow-id {
+      type uint8;
+      default 0;
+      description
+	"8-bit value that is used to provide per-flow entropy for flows in the same VSID";
+    }
+
+  }
+
+  grouping OFPortType {
+    description
+      "This grouping specifies all properties of an OpenFlow resource of type
+       OpenFlow Port. It represent a physical port or a logical port of
+       the OpenFlow Capable Switch and can be assigned for exclusive use
+       to an OpenFlow Logical Switch.  A logical port represents a tunnel
+       endpoint as described in the OpenFlow protocol specification
+       versions 1.3 - 1.3.1.";
+
+    uses OFResourceType;
+    leaf number {
+      type uint64;
+      config false;
+      description
+	"This number identifies the OpenFlow Port to OpenFlow Controllers. It is
+         assigned to an OpenFlow Port latest when the OpenFlow Port is
+        associated with and OpenFlow Logical Switch.  If the OpenFlow
+         Port is associated with an OpenFlow Logical Switch, this element
+         MUST be unique within the context of the OpenFlow Logical
+         Switch.
+      
+         OpenFlow Capable Switch implementations may choose to
+         assign values to OpenFlow Ports that are unique within the
+         context of the OpenFlow Logical Switch.  These numbers can
+         be used independent of assignments to OpenFlow Logical
+         Switches. 
+      
+         Other implementations may assign values to this element
+         only if the OpenFlow Port is assigned to an OpenFlow
+         Logical Switch.";
+    }
+
+    leaf requested-number {
+      type uint64 {
+	range "1..65279";
+      }
+      description
+	"This is the requested OpenFlow Port number for this interface. The switch
+         is expected to try and use the value of this lead as the port number for 
+         the interface. If the switch is unable to use the requested value or if
+         this leaf is not present, it will choose a free port to use.";
+    }
+
+    leaf name {
+      type string {
+	length "1..16";
+      }
+      config false;
+      description
+	"This element assists OpenFlow Controllers in identifying OpenFlow Ports.
+      
+         This element is not to be set by the OP-CONFIG protocol,
+         but it is set by the switch implementation.  It may be set
+         at start-up time of an OpenFlow Capable Switch or when the 
+         OpenFlow Port is assigned to an OpenFlow Logical Switch.
+         It MAY also be not set at all.  If this element is set to a
+         value other than the empty string when being assigned to an
+         OpenFlow Logical Switch, then the value of this element
+         MUST be unique within the context of the OpenFlow Logical
+         Switch.";
+    }
+
+    leaf current-rate {
+      when "../features/current/rate='other'" {
+        description
+	  "This element is only valid if the element rate of the current features
+           has value 'other'.";
+      }
+      type uint32;
+      units "kbit/s";
+      config false;
+      description
+	"This element indicates the current bit rate of the port. Its values is
+         to be provided in units of kilobit per second (kbps). This
+         element is only valid if the element called 'rate' in the
+         current Port Features has a value of 'other'.";
+    }
+
+    leaf max-rate {
+      when "../features/current/rate='other'" {
+        description
+	  "This element is only valid if the element rate of the current features
+           has value 'other'.";
+      }
+      type uint32;
+      units "kbit/s";
+      config false;
+      description
+	"This element indicates the maximum bit rate of the port. Its values is
+         to be provided in units of kilobit per second (kbps). This
+         element is only valid if the element called 'rate' in the
+         current Port Features has a value of 'other'.";
+    }
+
+    container configuration {
+      description
+	"This containter represents the general adminitrative configuration of the
+         OpenFlow Port.";
+
+      leaf admin-state {
+        type OFUpDownStateType;
+        default 'up';
+        description
+	  "The administrative state of the port.  If true, the port has been
+           administratively brought down and SHOULD not be used by
+           OpenFlow.";
+      }
+
+      leaf no-receive {
+        type boolean;
+        default false;
+        description
+	  "If true, packets received at this OpenFlow port SHOULD be dropped.";
+      }
+  
+      leaf no-forward {
+        type boolean;
+        default false;
+        description
+	  "If true, packets forwarded to this OpenFlow port SHOULD be dropped.";
+      }
+
+      leaf no-packet-in {
+        type boolean;
+        default false;
+        description
+	  "If true, packets received on that port that generate a table miss should
+           never trigger a packet-in message to the OpenFlow Controller.";
+      }
+    }
+
+    container state {
+      config false;
+      description
+	"This element represents the general operational state of the OpenFlow
+         Port.";
+
+      leaf oper-state {
+        type OFUpDownStateType;
+        description
+	  "If the value of this element is 'down', it indicates that there is no
+           physical link present.";
+      }
+
+      leaf blocked {
+        type boolean;
+        description
+	  "If the value of this element is 'true', it indicates that a switch
+           protocol outside of OpenFlow, such as 802.1D Spanning Tree, is
+           preventing the use of this OpenFlow port for OpenFlow
+           flooding.";
+      }
+
+      leaf live {
+        type boolean;
+        description
+	  "If the value of this element is 'true', it indicates that this OpenFlow
+           Port is live and can be used for fast failover.";
+      }
+    }
+    container features {
+      container current {
+        uses OFPortCurrentFeatureListType;
+        config false;
+        description
+	  "The features (rates, duplex, etc.) of the port, that are currently in
+           use.";
+      }
+
+      container advertised {
+        uses OFPortOtherFeatureListType;
+        description
+	  "The features (rates, duplex, etc.) of the port, that are advertised to
+           the peer port.";
+      }
+
+      container supported {
+        uses OFPortOtherFeatureListType;
+        config false;
+        description
+	  "The features (rates, duplex, etc.) of the port, that are supported on
+           the port.";
+      }
+
+      container advertised-peer {
+        uses OFPortOtherFeatureListType;
+        config false;
+        description
+	  "The features (rates, duplex, etc.) that are currently advertised by the
+           peer port.";
+      }
+    }
+
+    choice tunnel-type {
+      description
+	"Tunnels are modeled as logical ports.";
+
+      container tunnel {
+        description
+	  "Properties of a basic IP-in-GRE tunnel.";
+        uses OFPortBaseTunnelType;
+      }
+
+      container ipgre-tunnel {
+        description
+	  "Properties of a IP-in-GRE tunnel.";
+        uses OFPortIPGRETunnelType;
+      }
+
+      container vxlan-tunnel {
+        description
+	  "Properties of a VxLAN tunnel.";
+        uses OFPortVXLANTunnelType;
+      }
+
+      container nvgre-tunnel {
+        description
+	  "Properties of a NVGRE tunnel.";
+        uses OFPortNVGRETunnelType;
+      }
+    }
+  }
+
+  grouping OFQueueType {
+    description
+      "This grouping specifies all properties of a queue resource.";
+    uses OFResourceType;
+
+    leaf id {
+      type uint64;
+      mandatory true;
+      description
+	"This id identifies the OpenFlow Queue to OpenFlow Controllers. It is
+         assigned to an OpenFlow Queue latest when the OpenFlow Queue is
+         associated with and OpenFlow Logical Switch.  If the OpenFlow
+         Queue is associated with an OpenFlow Logical Switch, this
+         element MUST be unique within the context of the OpenFlow
+         Logical Switch.
+      
+         OpenFlow Capable Switch implementations may choose to
+         assign values to OpenFlow Queues that are unique within the
+         context of the OpenFlow Logical Switch.  These id can be
+         used independent of assignments to OpenFlow Logical
+         Switches. 
+      
+         Other implementations may assign values to this element
+         only if the OpenFlow Queue is assigned to an OpenFlow
+         Logical Switch.";
+    }
+
+    leaf port {
+      type leafref {
+        path "/capable-switch/resources/port/resource-id";
+      }
+      description
+	"Reference to port resources in the Capable Switch.
+      
+        This element associates an OpenFlow Queue with an OpenFlow
+        Port. If the OpenFlow Queue is associated with an OpenFlow
+        Logical Switch S and this element is present, then it MUST be
+        set to the value of element resource-id of an OpenFlow Port
+        which is associated with the OpenFlow Logical Switch.";
+    }
+
+    container properties {
+      description
+	"The queue properties currently configured.";
+
+      leaf min-rate {
+        type OFTenthOfAPercentType;
+        description
+	  "The minimal rate that is reserved for this queue in 1/10 of a percent of
+           the actual rate.
+
+           This element is optional. If not present a min-rate is not
+           set.";
+      }
+
+      leaf max-rate {
+        type OFTenthOfAPercentType;
+        description
+	  "The maximum rate that is reserved for this queue in 1/10 of a percent of
+           the actual rate.
+
+           This element is optional. If not present the max-rate is not
+           set.";
+      }
+
+      leaf experimenter-id {
+	type OFExperimenterId;
+	description
+	  "Experimenter ID of a currently configured experimenter.";
+      }
+      
+      leaf experimenter-data {
+	type hex-binary;
+	description
+	  "This leaf contains the rest of the experimenter queue property body and
+           is arbitrarily defined by the corresponding experimenter.";
+      }
+    }
+  }
+
+  grouping OFPortCurrentFeatureListType {
+    description
+      "The current features of a port.
+
+      Elements in the type OFPortCurrentFeatureListType are not
+      configurable and can only be retrieved by NETCONF <get>
+      operations.";
+
+    leaf rate {
+      type OFPortRateType;
+      description
+	"The transmission rate that is currently used.  The value MUST indicate a
+         valid forwarding rate.
+       
+         The current Port Feature set MUST contain this element exactly
+         once.  The other Port Feature sets MAY contain this element more
+         than once.  If this element appears more than once in a Port
+         Feature set than the value MUST be unique within the Port
+         Feature set.";
+    }
+
+    leaf auto-negotiate { 
+      type boolean;
+      description
+	"Specifies the administrative state of the forwarding rate
+         auto-negotiation protocol at this OpenFlow Port.";
+    }
+
+    leaf medium {
+      type enumeration {
+        enum copper;
+        enum fiber;
+      }
+      description
+	"This element MUST indicate a valid physical medium used by the OpenFlow
+         Port.
+      
+         The current Port Feature set MUST contain this element
+         exactly once. The other Port Feature sets MAY contain this
+         element more than once. If this element appears more than
+         once in a Port Feature set than the value MUST be unique
+         within the Port Feature set.";
+    }
+
+    leaf pause {
+      type enumeration {
+        enum unsupported;
+        enum symmetric;
+        enum asymmetric;
+      }
+      description
+	"Specifies if pausing of transmission is supported at all and if yes if
+         it is asymmetric or symmetric.";
+    }
+  }
+
+  grouping OFPortOtherFeatureListType {
+    description
+      "The features of a port that are supported or advertised.";
+
+    leaf-list rate {
+      type OFPortRateType;
+      min-elements 1;
+      description
+	"The transmission rate that is supported or advertised. Multiple
+         transmissions rates are allowed.";
+    }
+
+    leaf auto-negotiate { 
+      type boolean;
+      default true;
+      description
+	"Specifies if auto-negotiation of transmission parameters is enabled for
+         the port.";
+    }
+
+    leaf-list medium {
+      type enumeration {
+        enum copper;
+        enum fiber;
+      }
+      min-elements 1;
+      description
+	"The transmission medium used by the port. Multiple media are allowed.";
+    }
+
+    leaf pause {
+      type enumeration {
+        enum unsupported;
+        enum symmetric;
+        enum asymmetric;
+      }
+      mandatory true;
+      description
+	"Specifies if pausing of transmission is supported at all and if yes if
+         it is asymmetric or symmetric.";
+    }
+  }
+  
+  grouping OFExternalCertificateType {
+    description
+      "This grouping specifies a certificate that can be used by an OpenFlow
+       Logical Switch for authenticating a controller when a TLS
+       connection is established.";
+    uses OFResourceType;
+
+    leaf certificate {
+      type string;
+      mandatory true;
+      description
+	"An X.509 certificate in DER format base64 encoded.";
+    }
+  }
+  
+  grouping OFOwnedCertificateType {
+    description
+      "This grouping specifies a certificate and a private key. It can be used
+      by an OpenFlow Logical Switch for authenticating itself to a
+      controller when a TLS connection is established.";
+    uses OFResourceType;
+
+    leaf certificate {
+      type string;
+      mandatory true;
+      description
+	"An X.509 certificate in DER format base64 encoded.";
+    }
+
+    container private-key {
+      uses KeyValueType;
+      description
+	"This element contains the private key corresponding to the
+        certificate. The private key is encoded as specified in
+        XML-Signature Syntax and Processing
+        (http://www.w3.org/TR/2001/PR-xmldsig-core-20010820/).
+        Currently the specification only support DSA and RSA keys.";
+    }
+  }
+  
+  grouping KeyValueType {
+    description
+      "The KeyValue element contains a single public key that may be useful in
+       validating the signature.";
+
+    choice key-type {
+      mandatory true;
+      case dsa {
+        container DSAKeyValue {
+          uses DSAKeyValueType;
+        }
+      }
+      case rsa {
+        container RSAKeyValue {
+          uses RSAKeyValueType;
+        }
+      }
+    }
+  }
+  
+  grouping DSAKeyValueType {
+    description
+      "DSA keys and the DSA signature algorithm are specified in 'FIPS PUB
+    186-2, Digital Signature Standard (DSS), U.S. Department of
+    Commerce/National Institute of Standards and Technology,
+    http://csrc.nist.gov/publications/fips/fips186-2/fips186-2.pdf'.
+    DSA public key values can have the following fields:
+
+    P
+        a prime modulus meeting the requirements of the standard
+        above
+    Q
+        an integer in the range 2**159 < Q < 2**160 which is a
+        prime divisor of P-1
+    G
+        an integer with certain properties with respect to P and Q
+    J
+        (P - 1) / Q
+    Y
+        G**X mod P (where X is part of the private key and not made
+        public)
+    seed
+        a DSA prime generation seed
+    pgenCounter
+        a DSA prime generation counter
+
+    Parameter J is avilable for inclusion solely for efficiency as
+    it is calculatable from P and Q. Parameters seed and
+    pgenCounter are used in the DSA prime number generation
+    algorithm specified in the above standard. As such, they are
+    optional but MUST either both be present or both be absent.
+    This prime generation algorithm is designed to provide
+    assurance that a weak prime is not being used and it yields a P
+    and Q value. Parameters P, Q, and G can be public and common to
+    a group of users. They might be known from application context.
+    As such, they are optional but P and Q MUST either both appear
+    or both be absent. If all of P, Q, seed, and pgenCounter are
+    present, implementations are not required to check if they are
+    consistent and are free to use either P and Q or seed and
+    pgenCounter. All parameters are encoded as base64 values.";
+
+    leaf P {
+      when "count(../Q) != 0";
+      type binary;
+      mandatory true;
+      description
+	"A prime modulus meeting the requirements of the standard
+         above";
+    }
+
+    leaf Q {
+      when "count(../P) != 0";
+      type binary;
+      mandatory true;
+      description
+	"An integer in the range 2**159 < Q < 2**160 which is a
+         prime divisor of P-1";
+    }
+
+    leaf J {
+      type binary;
+      description
+	"(P - 1) / Q";
+    }
+
+    leaf G {
+      type binary;
+      description
+	"An integer with certain properties with respect to P and Q";
+    }
+
+    leaf Y {
+      type binary;
+      mandatory true;
+      description
+	"G**X mod P (where X is part of the private key and not made
+         public)";      
+    }
+
+    leaf Seed {
+      when "count(../PgenCounter) != 0";
+      type binary;
+      mandatory true;
+      description
+	"A DSA prime generation seed";
+
+    }
+    leaf PgenCounter {
+      when "count(../Seed) != 0";
+      type binary;
+      mandatory true;
+      description
+	"A DSA prime generation counter";
+    }
+  }
+   
+  grouping RSAKeyValueType {
+    description
+      "RSA key values have two fields: Modulus and Exponent.";
+
+    leaf Modulus {
+      type binary;
+      mandatory true;
+    }
+
+    leaf Exponent {
+      type binary;
+      mandatory true;
+    }
+  }
+  
+  grouping OFFlowTableType {
+    description
+      "Representation of an OpenFlow Flow Table Resource.";
+
+    uses OFResourceType;
+
+    leaf table-id {
+      type uint8;
+
+      description
+	"Identifier of table.";
+    }
+
+    leaf name {
+      type string;
+
+      description
+	"Table name";
+    }
+
+    leaf metadata-match {
+      type hex-binary {
+	length 16;
+      }
+
+      description
+	"This element indicates the bits of the metadata field on which the flow
+         table can match on.  It is represented as a 64-bit integer in
+         hexadecimal digits([0-9a-fA-F]) format.";
+    }
+
+    leaf metadata-write {
+      type hex-binary {
+	length 16;
+      }
+	
+      description
+	"This element indicates the bits of the metadata field on which flow
+         table can write using the 'write-metadata' instruction.  It is
+         represented as a 64-bit integer in hexadecimal digits([0-9a-fA-F])
+         format.";
+    }
+
+    leaf max-entries {
+      type uint32;
+      config false;
+
+      description
+	"The maximum number of flow entries supported by the flow table.";
+    }
+
+    container properties {
+      presence "This table exposes feature properties";
+
+      description
+	"Table feature properties representing all possible features of a
+         table. Each container represent a single table feature
+         property.
+
+         According to the specification, clients should understand that
+         the properties with the -miss suffix may be omitted if it is
+         the same as the corresponding property for regular flow
+         entries.";
+
+      container instructions {
+	leaf-list type {
+	  type OFInstructionType;
+
+	  description
+	    "The list of instruction types supported by this table for regular flow
+             entries";
+	}
+      }
+
+      container instructions-miss {
+	leaf-list type {
+	  type OFInstructionType;
+
+	  description
+	    "The list of all instruction types supported by this table for
+             table-miss flow entries";
+	}
+      }
+
+      container next-tables {
+	leaf-list table-id {
+	  type uint8;
+
+	  description
+	    "An array of resource-ids of all flow tables that can be directly reached
+             from this table using the 'goto-table' instruction for regular flow
+             entries.";
+	}
+      }
+
+      container next-tables-miss {
+	leaf-list table-id {
+	  type uint8;
+
+	  description
+	    "An array of resource-ids of all flow tables that can be directly reached
+             from this table using the 'goto-table' instruction for the table-miss flow
+             entry.";
+	}
+      }
+
+      container write-actions {
+	leaf-list type {
+	  type OFActionType;
+
+	  description
+	    "The list of all write action types supported by this table for regular
+             flow entries.";
+	}
+      }
+
+      container write-actions-miss {
+	leaf-list type {
+	  type OFActionType;
+
+	  description
+	    "The list of all write action types supported by this table for table-miss
+             flow entries.";
+	}
+      }
+
+      container apply-actions {
+	leaf-list type {
+	  type OFActionType;
+
+	  description
+	    "The list of all apply action types supported by the flow table for
+             regular flow entries.";
+	}
+      }
+
+      container apply-actions-miss {
+	leaf-list type {
+	  type OFActionType;
+
+	  description
+	    "The list of all apply action types supported by the flow table for
+             table-miss flow entries.";
+	}
+      }
+
+      container matches {
+	leaf-list type {
+	  type OFMatchFieldType;
+
+	  description
+	    "The list of all match types supported by this table for regular
+             flow entries.";
+	}
+      }
+
+      container wildcards {
+	leaf-list type {
+	  type OFMatchFieldType;
+
+	  description
+	    "The list of all fields for which the table supports wildcarding.";
+	}
+      }
+
+      container write-setfields {
+	leaf-list type {
+	  type OFMatchFieldType;
+
+	  description
+	    "The list of all 'set-field' action types supported by this table using
+             write actions for regular flow entries.";
+	}
+      }
+
+      container write-setfields-miss {
+	leaf-list type {
+	  type OFMatchFieldType;
+
+	  description
+	    "The list of all 'set-field' action types supported by this table using
+             write actions for table-miss flow entries.";
+	}
+      }
+
+      container apply-setfields {
+	leaf-list type {
+	  type OFMatchFieldType;
+
+	  description
+	    "The list of all 'set-field' action types supported by the table using
+             apply actions for regular flow entries.";
+	}
+      }
+
+      container apply-setfields-miss {
+	leaf-list type {
+	  type OFMatchFieldType;
+
+	  description
+	    "The list of all 'set-field' action types supported by the table using
+             apply actions for table-miss flow entries.";
+	}
+      }
+
+      container experimenter {
+	leaf-list experimenter-id {
+	  type OFExperimenterId;
+
+	description
+	  "The list of all experimenters supported by the table for regular
+           flow entries.";
+        }
+      }
+
+      container experimenter-miss {
+	leaf-list experimenter-id {
+	  type OFExperimenterId;
+
+	  description
+	    "The list of all experimenters supported by the table for table-miss
+             flow entries.";
+	}
+      }
+    }
+  }
+
+/*****************************************************************
+ * Main container
+ *****************************************************************/
+
+  container capable-switch {
+    description
+      "The OpenFlow Capable Switch serves as the root element for an OpenFlow
+       configuration.  It contains logical switches and resources that
+       can be assigned to logical switches.  It may have relations to
+       OpenFlow Configuration Points.";
+
+    leaf id {
+      type string;
+      mandatory true;
+      description
+	"A unique but locally arbitrary identifier that uniquely identifies a
+         Capable Switch within the context of potential OpenFlow
+         Configuration Points.  It MUST be persistent across reboots of
+         the OpenFlow Capable Switch.";
+    }
+
+    leaf config-version {
+      type string;
+      config false;
+      description
+	"The maximum supported OF-CONFIG version that is supported by the
+         OpenFlow Capable Switch. For switches implementing this version
+         of the OF-CONFIG protocol this MUST always be 1.2.
+
+         This object can be used to identify the OF-CONFIG version
+         a capable switch supports beginning with version 1.1.1 of 
+         OF-CONFIG. In addtion the supported version can be
+         determined by the namespace the OpenFlow Capable Switch
+         returns to configuration request of an element (like 
+         capable-switch) that is present in all OF-CONFIG versions
+         specified so far. This is the only possiblity to identify
+         OF-CONFIG versions prior to OF-CONFIG 1.1.1.";
+    }
+
+    container configuration-points {
+      list configuration-point {
+        key "id";
+        description
+	  "The list of all Configuration Points known to the OpenFlow Capable
+           Switch that may manage it using OF-CONFIG.";
+
+        uses OFConfigurationPointType;
+      }
+    }
+
+    container resources {
+      description
+	"A lists containing all resources of the OpenFlow Capable Switch that can
+         be used by OpenFlow Logical Switches.  Resources are listed here
+         independent of their actual assignment to OpenFlow Logical
+         Switches.  They may be available to be assigned to an OpenFlow
+         Logical Switch or already in use by an OpenFlow Logical Switch.";
+
+      list port {
+        must "features/current/rate != 'other' or " +
+          "(count(current-rate) = 1 and count(max-rate) = 1 and " +
+          " current-rate > 0 and max-rate > 0)" {
+          error-message
+	    "current-rate and max-rate must be specified and greater than 0 if rate
+             equals 'other'";
+          description
+	    "current-rate and max-rate can only be present if rate = 'other', see
+             corresponding leaf descriptions. If rate = 'other', then
+             both leafs must be set to values greater than zero.";
+        }
+
+        key "resource-id";
+        description
+	  "The list contains all port resources of the OpenFlow Capable Switch.
+
+          The element 'resource-id' of OFPortType MUST be unique within
+          this list.";
+        uses OFPortType;
+      }
+
+      list queue {
+        key "resource-id";
+        description
+	  "The list contains all queue resources of the OpenFlow Capable Switch.";
+        uses OFQueueType;
+      }
+
+      list owned-certificate {
+        key "resource-id";
+        description
+	  "The list contains all owned certificate resources of the OpenFlow
+           Capable Switch.";
+        uses OFOwnedCertificateType;
+      }
+
+      list external-certificate {
+        key "resource-id";
+        description
+	  "The list contains all external certificate resources of the OpenFlow
+           Capable Switch.";
+        uses OFExternalCertificateType;
+      }
+
+      list flow-table {
+        key table-id;
+        description
+	  "The list contains all flow table resources of the OpenFlow Capable
+           Switch.";
+        uses OFFlowTableType;
+      }
+    }
+
+    container logical-switches {
+      description
+	"This element contains a list of all OpenFlow Logical Switches available
+         at the OpenFlow Capable Switch.";
+
+      list switch {
+        key "id";
+        description
+	  "The list of all OpenFlow Logical Switches on the OpenFlow Capable
+           Switch.";
+        uses OFLogicalSwitchType;
+      }
+    }
+  }  
+}


### PR DESCRIPTION
2019年12月30日 提供最新版yang文件。
与之前相比：
1，增加了《of-config-1.2-sptn-event.yang》。
2，删除了《of-config-1.2-sptn-vpls.yang》。
3，《of-config-1.2-sptn-clock.yang》中的leaf-list system-clock-source-priority-list 增加 ordered-by user;
4，《of-config-1.2-sptn-lag.yang》将 lag 节点放入 "/of-config:capable-switch/of-config:resources"中，在 lag 节点中 加入 leaf openflow-port。
5，《of-config-1.2-sptn-link-oam.yang》将 loopback-status 拆分为 loopback-cmd 和 loopback-status。
6，《of-config-1.2-sptn-port-ext.yang》在 tdm 节点下增加 tdm-e1-status。用于控制器查询 TDM业务性能数据。
